### PR TITLE
ci: bump golangci-lint-action to v7 for golangci-lint v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Verify modules
         run: go mod verify
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2
       - name: govulncheck


### PR DESCRIPTION
golangci-lint-action v6 does not support golangci-lint v2.x and fails with 'invalid version string'. v7 is required for the v2 series.
