### PR TITLE
ci: bring repo up to standard v1.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  commit-format:
+    name: commit format (dependency-free commitlint equivalent)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Check Conventional Commits format in PR
+        run: |
+          # Regex pattern: type(scope)?: subject (matches release.sh)
+          pattern='^[a-z]+(\([^)]*\))?!?:'
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          # Get all commits in the PR, excluding merge commits
+          commits=$(git log --no-merges --format='%H %s' "$base..$head")
+
+          if [ -z "$commits" ]; then
+            echo "No commits found in range $base..$head"
+            exit 0
+          fi
+
+          failed=0
+          while IFS= read -r commit_hash subject; do
+            if ! echo "$subject" | grep -qE "$pattern"; then
+              echo "::error::Commit $commit_hash violates Conventional Commits: '$subject'"
+              failed=1
+            fi
+          done <<< "$commits"
+
+          if [ $failed -eq 1 ]; then
+            echo ""
+            echo "All commits must follow Conventional Commits format:"
+            echo "  type(scope)?: description"
+            echo ""
+            echo "Valid types: feat, fix, docs, chore, test, refactor, build, perf, ci, style"
+            exit 1
+          fi
+
   test:
     name: test (go ${{ matrix.go }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,8 @@ jobs:
         run: CGO_ENABLED=0 go build -tags embed ./...
       - name: Vet
         run: go vet ./...
-      - name: Test (race + coverage)
-        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
-      - name: Coverage gate (>= 80%)
-        run: |
-          total=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub(/%/,"",$3); print $3}')
-          echo "total coverage: ${total}%"
-          awk "BEGIN{ exit !(${total}+0 >= 80) }" \
-            || { echo "FAIL: coverage ${total}% is below the 80% gate"; exit 1; }
+      - name: Test + coverage gate (total + per-package, >= 80%)
+        run: make cover
       - name: Benchmarks (smoke, 1x)
         run: go test -run='^$' -bench=. -benchmem -benchtime=1x ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   goreleaser:
@@ -19,6 +20,8 @@ jobs:
           # Build shipped binaries with the latest stable Go so they carry all
           # runtime/stdlib security fixes, independent of the go.mod floor.
           go-version: stable
+      - uses: sigstore/cosign-installer@v3
+      - uses: anchore/sbom-action/download-syft@v0
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,6 +39,21 @@ archives:
 checksum:
   name_template: checksums.txt
 
+sboms:
+  - artifacts: archive
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - --output-signature=${signature}
+      - --output-certificate=${certificate}
+      - ${artifact}
+      - --yes
+    artifacts: checksum
+
 changelog:
   use: github
   sort: asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,15 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
 - `ingest <path>` confines its scan root to the kb, like `okfy`; an out-of-tree
   path is refused with guidance.
 
+### Fixed
+- `mnemos.remember` to an explicit path now preserves a body's existing frontmatter
+  instead of prepending a second block. Read-modify-write of a stateful document (a
+  task state file, `status.md`, a decision) is lossless: the author's
+  `status`/`priority`/`title` are no longer shadowed by a generated block that carried
+  only `type`/`tags`/`timestamp`/`collection`, so a remembered `type: task` document
+  groups correctly in `mnemos task list`. Inbox captures (no path) still generate
+  frontmatter as before. New `ingest.PrepareOKF` seam; `RenderOKF` unchanged.
+
 ### Removed
 - Config keys `[storage].path` and `[capture].dir`, and the layered
   `~/.mnemos.toml` + `./.mnemos.toml` discovery — superseded by the single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
 - Single cgo-free Go binary bundling an MCP server, indexing pipeline, SQLite
   store, full-text search, an incremental file watcher, and an admin CLI.
 - Indexing pipeline: directory scanning, content-hash change detection, and
-  chunking for text, Markdown, and Go source, with token-aware splitting.
+  chunking for text, Markdown, and Go source, with token-aware splitting. A
+  Markdown document's stored `documents.title` honors an explicit frontmatter
+  `title:` (falling back to the first heading, then the first non-empty body
+  line), so an OKF document is no longer mislabelled by its first `##` heading
+  in `search`/`context`/`list`. Existing documents pick up the corrected title
+  on their next re-ingest (unchanged files are content-hash-skipped).
 - Lexical retrieval over SQLite FTS5 with bm25 ranking; frontmatter `tags`/`type`
   contribute fuzzy ranking signals. Citations report `uri#section` and line ranges.
   Search over-fetches a candidate pool before applying the heading-path boost, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,15 +36,22 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   a subset of its chunks; `search` scores are rounded to one decimal.
 - Native OKF (Open Knowledge Format) support: frontmatter, cross-link edges
   (stored), and `index.md` structure handling.
-- MCP tools: `search`, `read`, `context`, `remember`, `okfy`, `list`, `forget`,
-  `move`. Write/delete tools are gated behind `allow_write` / `allow_delete`.
+- MCP tools: `search`, `read`, `context`, `list`, `related`, `remember`, `okfy`,
+  `forget`, `move`. Write/delete tools are gated behind `allow_write` /
+  `allow_delete`.
+- Link-graph traversal: `related` (MCP tool and CLI) returns a document's 1-hop
+  neighbors, the outbound links it contains and the inbound backlinks that point
+  at it (document-level, directed). Dangling outbound targets surface with
+  `resolved:false`; neighbors honor the `[security].visibility.deny` boundary.
+  Backed by a new `idx_links_dst_doc` index so inbound lookups no longer scan the
+  whole links table.
 - Move (`mv`/`mnemos.move`) un-indexes old URIs before the on-disk rename, so a
   failure never leaves phantom URIs in the index; directory moves are best-effort
   and report an aggregated error, and the count of orphaned inbound links is
   surfaced to the caller. See ADR 0004.
-- CLI: `init`, `ingest`, `search`, `ls`, `eval`, `watch`, `serve`, `status`,
-  `version`, `models install`, `reindex`, `validate`, `task list`, `forget`,
-  `mv`, `okfy`.
+- CLI: `init`, `ingest`, `search`, `ls`, `related`, `eval`, `watch`, `serve`,
+  `status`, `version`, `models install`, `reindex`, `validate`, `task list`,
+  `forget`, `mv`, `okfy`.
 - `reindex --content` re-parses and rewrites every already-indexed document from
   its on-disk file, bypassing the unchanged-file content-hash skip, so a parser or
   schema change (e.g. the frontmatter-title fix) propagates to the whole index

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
 - CLI: `init`, `ingest`, `search`, `ls`, `eval`, `watch`, `serve`, `status`,
   `version`, `models install`, `reindex`, `validate`, `task list`, `forget`,
   `mv`, `okfy`.
+- `reindex --content` re-parses and rewrites every already-indexed document from
+  its on-disk file, bypassing the unchanged-file content-hash skip, so a parser or
+  schema change (e.g. the frontmatter-title fix) propagates to the whole index
+  without editing files. It walks the documents table, preserving each document's
+  stored collection, and leaves rows whose file has vanished in place. Rewriting
+  chunks cascades away their embeddings, so it advises a follow-up
+  `reindex --embeddings`; `--content` and `--embeddings` may be combined (content
+  runs first). Normal ingest/watch stay hash-skip-fast (the new `ingest.Options.Force`
+  defaults off).
 - Incremental file watcher with debounce/coalescing that reindexes changed files
   and removes deleted ones.
 - Retrieval-quality evaluation (`mnemos eval`) over OKF bundles: auto-derived

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,12 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   path is refused with guidance.
 
 ### Fixed
+- `mnemos task list` now titles each task from its frontmatter `title:` (falling back to
+  the heading-derived title only when absent), instead of always showing the first
+  heading — so a task file whose first heading is `## Goal` no longer lists as "Goal". It
+  also shows each task's collection, and filters `type`/`status` in SQL via `json_extract`
+  (guarded by `json_valid`) rather than scanning every document and JSON-decoding it in
+  Go. `ListFilter` gains `DocType`/`Status`.
 - `mnemos.remember` to an explicit path now preserves a body's existing frontmatter
   instead of prepending a second block. Read-modify-write of a stateful document (a
   task state file, `status.md`, a decision) is lossless: the author's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   `resolved:false`; neighbors honor the `[security].visibility.deny` boundary.
   Backed by a new `idx_links_dst_doc` index so inbound lookups no longer scan the
   whole links table.
+- Graph-assisted retrieval (`[search] graph_expansion`, off by default): a
+  `GraphRetriever` wraps the lexical/hybrid retriever and, when a query
+  under-fills the limit, fills the empty slots with the top hits' 1-hop link
+  neighbors (decayed seed score, first-chunk citation). It never reorders or
+  evicts base results, so ranking metrics cannot regress; it respects the
+  visibility deny list and skips dangling targets. Tunable via `graph_seed_depth`
+  and `graph_decay`. Gated by eval: `mnemos eval <bundle> --graph-expansion`
+  measures held-out Hit@1/Recall/MRR with expansion on (flat on git-recipes), and
+  `mnemos eval --graph` now reports the actual GraphRetriever hit@K (0.20 -> 0.80
+  on the graph-answerability bundle).
 - Opt-in link-neighborhood injection: `mnemos.read` and `mnemos.context` accept
   `follow_links` (plus `link_limit` / `link_direction`) to attach a document's
   1-hop neighbors to the response. Off by default and best-effort (it never fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,10 +100,22 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   overwritten, journaled passes). Frontmatter contracts and the full
   consolidation procedure live in `references/task-schema.md` and
   `references/consolidation.md`, read on demand.
-- Claude Code hooks example at `skills/mnemos-okf/hooks/settings.example.json`:
-  deterministic working-set injection via `SessionStart` (at startup, resume,
-  and after compaction) and cue-gated recall via `UserPromptSubmit`; requires
-  `jq`; silent no-op when no cue matches.
+- Native `mnemos hook session-start` and `mnemos hook recall` subcommands
+  (plan §4.1-4.2) replace the former multi-process, `jq`-dependent hook shell
+  pipelines. Each is one Go process that reads the Claude Code event JSON from
+  stdin and resolves the workspace first, staying completely silent (no output,
+  exit 0) when the project has no mnemos workspace so an uninitialized project
+  never leaks the global store. `session-start` injects the scoped working set
+  (open `in_progress`/`todo` tasks — never `done` — and recent decisions),
+  labelling lines by collection when the global store is in scope, under a
+  `--max-tokens` cap. `recall` extracts salient (stopword-stripped) terms from
+  the prompt, runs a lexical-only search (never loads the embedding model in the
+  hot path), and injects the top cited hits — staying silent on no hits and on
+  input that is neither cue-phrased nor question-shaped, so it no longer injects
+  "no results" noise.
+- Claude Code hooks example at `skills/mnemos-okf/hooks/settings.example.json`
+  wires those subcommands to `SessionStart` (at startup, resume, and after
+  compaction) and `UserPromptSubmit`; no `jq` dependency.
 - `make install-hooks` target merges those hooks into `~/.claude/settings.json`
   idempotently (marker-keyed, keeps a `.bak`); `install-skill` now calls it so a
   single install both copies the skill and activates its hooks. `SKIP_HOOKS=1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   deterministic working-set injection via `SessionStart` (at startup, resume,
   and after compaction) and cue-gated recall via `UserPromptSubmit`; requires
   `jq`; silent no-op when no cue matches.
+- `make install-hooks` target merges those hooks into `~/.claude/settings.json`
+  idempotently (marker-keyed, keeps a `.bak`); `install-skill` now calls it so a
+  single install both copies the skill and activates its hooks. `SKIP_HOOKS=1`
+  opts out.
 - `examples/project-memory/`: OKF-conformant project-memory bundle (status,
   constraints, decisions, tasks with state/history split, consolidation journal)
   demonstrating `mnemos add` and `mnemos task list`.
@@ -99,6 +103,14 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   resolution source, kb root, index db).
 
 ### Changed
+- Workspace resolution adds a `$CLAUDE_PROJECT_DIR` rung (precedence 4, after
+  `$MNEMOS_DIR` and before the cwd walk-up): an unpinned `mnemos serve` in a Claude
+  Code session resolves the session's project instead of leaking the global `~/.mnemos`.
+  It fails closed: a signalled project with no `.mnemos` binds to its canonical
+  uninitialized location so an absent database reports "run mnemos init" rather than
+  silently serving the global KB. Bare invocations with no `$CLAUDE_PROJECT_DIR` still
+  fall back to the global default. See ADR 0005 (amended). MCP `roots/list` resolution
+  and a degraded no-workspace serve mode are deferred follow-ups.
 - Configuration carries behaviour only (`[indexing]`, `[chunking]`, `[search]`,
   `[mcp]`, `[capture].defer_to_watcher`, `[security]`). All content and state
   locations are derived from `MNEMOS_DIR`, not configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
 - Retrieval-quality evaluation (`mnemos eval`) over OKF bundles: auto-derived
   held-out query→source pairs reporting Hit@1 / Recall@12 / MRR@12 against a
   committed baseline.
+- Collection visibility boundary: `[security].visibility.deny` lists collections
+  hidden from every query surface (`search`, `context`, `list`, `task`), enforced
+  server-side in the query layer — a denied collection never surfaces even when a
+  caller names it explicitly. Empty by default (nothing hidden), so a single-store
+  KB stays fully visible until configured. `search` results and `context` blocks
+  now also carry their `collection` as a provenance label. See plan §5.2.
 - Security: stdio-only MCP server, read-only by default, path-confinement guard
   (rejects `..` traversal, symlink escapes, `.mnemos/` access, and configured
   exclusion globs), and secret-scanning of captured content before write/index.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   `resolved:false`; neighbors honor the `[security].visibility.deny` boundary.
   Backed by a new `idx_links_dst_doc` index so inbound lookups no longer scan the
   whole links table.
+- Opt-in link-neighborhood injection: `mnemos.read` and `mnemos.context` accept
+  `follow_links` (plus `link_limit` / `link_direction`) to attach a document's
+  1-hop neighbors to the response. Off by default and best-effort (it never fails
+  an otherwise-successful read/context); context computes neighbors once per
+  document across the result set. Justified by the graph-answerability eval below.
 - Graph-answerability eval (`mnemos eval <bundle> --graph`): reads a curated
   `cases.json` and measures whether 1-hop link-neighborhood injection surfaces the
   answer document that plain lexical search misses, reporting direct hit@K,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   Search over-fetches a candidate pool before applying the heading-path boost, so
   a boosted chunk can be promoted into the top results instead of being truncated
   by the bm25 `LIMIT`.
+- Result shaping at the MCP boundary to cut follow-up `read` calls and response
+  size (plan §3.3): `search`/`context` return the real `documents.title` and
+  `modified_at` instead of a heading-derived label; a heading/tag-only hit whose
+  content snippet is empty falls back to its heading path rather than a blank
+  line; `context` defaults to `group_by=document` (best chunk per document, with
+  `group_by=chunk` for the flat listing) and trims the low-relevance tail at a
+  relevance cliff; `context`/`read` accept `max_chars`/`max_tokens` budgets (with
+  a `truncated` flag) and `read` accepts `section`/`lines` to scope a document to
+  a subset of its chunks; `search` scores are rounded to one decimal.
 - Native OKF (Open Knowledge Format) support: frontmatter, cross-link edges
   (stored), and `index.md` structure handling.
 - MCP tools: `search`, `read`, `context`, `remember`, `okfy`, `list`, `forget`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,14 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   resolution source, kb root, index db).
 
 ### Changed
+- MCP tool responses are serialized once on the wire instead of twice. Previously every
+  response was emitted as both `structuredContent` and an identical mirrored `text` block;
+  handlers now build the result explicitly and default to a single text block (the form
+  the client already surfaces to the model), halving response bytes. A new
+  `[mcp].result_mode` (`text` default, or `structured`/`both`) selects the shape; an
+  unknown value is rejected at config load. Registering handlers with an untyped output
+  also drops the advertised per-tool output schema (intended: it removes the hook the SDK
+  used to auto-mirror, and trims the tool-surface token cost).
 - Workspace resolution adds a `$CLAUDE_PROJECT_DIR` rung (precedence 4, after
   `$MNEMOS_DIR` and before the cwd walk-up): an unpinned `mnemos serve` in a Claude
   Code session resolves the session's project instead of leaking the global `~/.mnemos`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ pure-Go, and cgo-free; semantic/hybrid search is implemented and ships behind th
   `resolved:false`; neighbors honor the `[security].visibility.deny` boundary.
   Backed by a new `idx_links_dst_doc` index so inbound lookups no longer scan the
   whole links table.
+- Graph-answerability eval (`mnemos eval <bundle> --graph`): reads a curated
+  `cases.json` and measures whether 1-hop link-neighborhood injection surfaces the
+  answer document that plain lexical search misses, reporting direct hit@K,
+  neighbor inclusion, lift, and recovered-misses. Ships with the
+  `examples/graph-answerability` bundle. This is the instrument that must justify
+  read/context neighborhood injection before it is built; the existing held-out
+  eval cannot, because injection does not change ranking. Also adds neighbor-query
+  and read-vs-read+inject benchmarks for the injection cost side.
 - Move (`mv`/`mnemos.move`) un-indexes old URIs before the on-disk rename, so a
   failure never leaves phantom URIs in the index; directory moves are best-effort
   and report an aggregated error, and the count of orphaned inbound links is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ quality bar, and how to get a change merged.
 git clone https://github.com/arhuman/mnemos.git && cd mnemos
 make build        # cgo-free binary -> bin/mnemos
 make test         # go test -race ./...
+make git-hooks    # install local git commit-msg hook (enforces Conventional Commits)
 ```
 
 Useful targets (`make help` lists them all):
@@ -73,8 +74,9 @@ Before opening a PR:
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
 (`feat:`, `fix:`, `docs:`, `build:`, `ci:`, `refactor:`, `test:`, `chore:`),
-enforced by commitlint. Keep commits atomic and focused. Use a `!` or a
-`BREAKING CHANGE:` footer for breaking changes.
+enforced in CI and locally via git commit-msg hook (set up with `make git-hooks`).
+Keep commits atomic and focused. Use a `!` or a `BREAKING CHANGE:` footer for
+breaking changes.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,25 @@ bench:
 bench-smoke:
 	go test -run='^$$' -bench=. -benchmem -benchtime=1x ./...
 
-## cover: run tests with coverage, write reports, fail under COVER_MIN%
+## cover: run tests with coverage, write reports, fail under COVER_MIN% total or per package
 cover:
-	go test -race -covermode=atomic -coverprofile=$(COVER_OUT) ./...
+	go test -race -covermode=atomic -coverpkg=./internal/... -coverprofile=$(COVER_OUT) ./...
 	go tool cover -func=$(COVER_OUT)
 	go tool cover -html=$(COVER_OUT) -o $(COVER_HTML)
 	@total=$$(go tool cover -func=$(COVER_OUT) | awk '/^total:/ {gsub(/%/,"",$$3); print $$3}'); \
 	echo "total coverage: $$total% (minimum $(COVER_MIN)%)"; \
 	awk "BEGIN{ exit !($$total+0 >= $(COVER_MIN)) }" || \
 	  { echo "FAIL: total coverage $$total% is below the $(COVER_MIN)% gate"; exit 1; }
+	@echo "per-package floor: minimum $(COVER_MIN)% (--coverpkg cross-package attribution)"; \
+	awk -v min=$(COVER_MIN) 'NR>1 { k=$$1; st[k]=$$2; hit[k]+=$$3 } \
+	  END { \
+	    for (k in st) { split(k,a,":"); f=a[1]; n=split(f,p,"/"); d=p[1]; \
+	      for (i=2;i<n;i++) d=d"/"p[i]; tot[d]+=st[k]; if (hit[k]>0) cov[d]+=st[k] } \
+	    fail=0; \
+	    for (d in tot) { pct=100*cov[d]/tot[d]; \
+	      if (pct+0 < min+0) { printf "  FAIL %5.1f%%  %s\n", pct, d; fail=1 } } \
+	    if (fail) { print "FAIL: a package is below the " min "% per-package gate"; exit 1 } \
+	    print "  all internal packages >= " min "%" }' $(COVER_OUT)
 
 ## tidy: tidy go.mod and gofmt the source tree
 tidy:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 VPKG       := github.com/arhuman/mnemos/internal/version
 LDFLAGS    := -ldflags "-X $(VPKG).Version=$(VERSION) -X $(VPKG).GitCommit=$(COMMIT) -X $(VPKG).BuildDate=$(BUILD_DATE)"
 
-.PHONY: build build-embed test bench bench-smoke cover tidy audit tools install install-embed install-skill install-hooks demo demo-check clean help
+.PHONY: build build-embed test bench bench-smoke cover tidy audit ci tools install install-embed install-skill install-hooks git-hooks demo demo-check clean help release
 
 # First target is the default (`make` == `make build`).
 ## build: compile the single binary (cgo-free) into bin/
@@ -87,6 +87,14 @@ audit:
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 	$(MAKE) cover
 
+## ci: run full CI checks locally (build, vet, mod verify, lint, vuln, coverage gate)
+ci: build build-embed
+	go vet ./...
+	go mod verify
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION) run
+	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+	$(MAKE) cover
+
 ## install: install the binary into GOBIN (cgo-free)
 install:
 	CGO_ENABLED=0 go install $(LDFLAGS) $(CMD)
@@ -118,6 +126,12 @@ else
 	@echo "SKIP_HOOKS set -> leaving $(CLAUDE_SETTINGS) untouched"
 endif
 
+## git-hooks: install git commit hooks via lefthook (enforces Conventional Commits locally)
+git-hooks:
+	@command -v lefthook >/dev/null || { echo "lefthook not found: install with 'go install github.com/evilmartians/lefthook@latest' or 'brew install lefthook'"; exit 1; }
+	@lefthook install
+	@echo "git hooks installed from lefthook.yml"
+
 ## demo: render the README demo GIFs from the VHS tapes (needs vhs + mnemos on PATH; demo-mcp also needs claude)
 demo:
 	@which vhs > /dev/null || { echo "vhs not found: install github.com/charmbracelet/vhs"; exit 1; }
@@ -131,6 +145,10 @@ demo-check:
 ## clean: remove build artifacts
 clean:
 	rm -rf $(BIN_DIR) $(COVER_OUT) $(COVER_HTML)
+
+## release: cut a release (derives semver from commits, gates on make ci, stamps CHANGELOG.md, tags, pushes)
+release:
+	@./scripts/release.sh
 
 ## help: list available targets
 help:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ COVER_OUT  := coverage.out
 COVER_HTML := coverage.html
 SKILL_SRC  := skills/mnemos-okf
 SKILL_DEST := $(HOME)/.claude/skills/mnemos-okf
+CLAUDE_SETTINGS := $(HOME)/.claude/settings.json
+HOOKS_SRC       := $(SKILL_SRC)/hooks/settings.example.json
 TAPES      := docs/demo.tape docs/demo-mcp.tape
 
 # Pinned dev-tool versions installed by `make tools` (reproducible audits).
@@ -23,7 +25,7 @@ BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 VPKG       := github.com/arhuman/mnemos/internal/version
 LDFLAGS    := -ldflags "-X $(VPKG).Version=$(VERSION) -X $(VPKG).GitCommit=$(COMMIT) -X $(VPKG).BuildDate=$(BUILD_DATE)"
 
-.PHONY: build build-embed test bench bench-smoke cover tidy audit tools install install-embed install-skill demo demo-check clean help
+.PHONY: build build-embed test bench bench-smoke cover tidy audit tools install install-embed install-skill install-hooks demo demo-check clean help
 
 # First target is the default (`make` == `make build`).
 ## build: compile the single binary (cgo-free) into bin/
@@ -83,12 +85,28 @@ install:
 install-embed:
 	CGO_ENABLED=0 go install -tags embed $(LDFLAGS) $(CMD)
 
-## install-skill: install the Claude Code mnemos-okf skill into ~/.claude/skills/
+## install-skill: install the mnemos-okf skill into ~/.claude/skills/ and merge its hooks
 install-skill:
 	rm -rf $(SKILL_DEST)
 	mkdir -p $(SKILL_DEST)
 	cp -R $(SKILL_SRC)/. $(SKILL_DEST)/
 	@echo "installed skill -> $(SKILL_DEST)"
+	@$(MAKE) install-hooks
+
+## install-hooks: merge mnemos SessionStart/UserPromptSubmit hooks into ~/.claude/settings.json (idempotent; SKIP_HOOKS=1 to skip)
+install-hooks:
+ifndef SKIP_HOOKS
+	@command -v jq >/dev/null || { echo "jq not found: required to merge hooks (brew install jq)"; exit 1; }
+	@mkdir -p $(dir $(CLAUDE_SETTINGS))
+	@[ -f $(CLAUDE_SETTINGS) ] || echo '{}' > $(CLAUDE_SETTINGS)
+	@cp $(CLAUDE_SETTINGS) $(CLAUDE_SETTINGS).bak
+	@jq -n --slurpfile cur $(CLAUDE_SETTINGS) --slurpfile add $(HOOKS_SRC) \
+	  '($$cur[0] // {}) as $$c | ($$add[0].hooks) as $$h | $$c | .hooks = (.hooks // {}) | reduce ($$h | keys_unsorted[]) as $$k (.; .hooks[$$k] = (((.hooks[$$k] // []) | map(select([.hooks[]?.command // ""] | any(test("mnemos-okf-hook")) | not))) + $$h[$$k]))' \
+	  > $(CLAUDE_SETTINGS).tmp && mv $(CLAUDE_SETTINGS).tmp $(CLAUDE_SETTINGS)
+	@echo "merged mnemos hooks -> $(CLAUDE_SETTINGS) (backup: $(CLAUDE_SETTINGS).bak)"
+else
+	@echo "SKIP_HOOKS set -> leaving $(CLAUDE_SETTINGS) untouched"
+endif
 
 ## demo: render the README demo GIFs from the VHS tapes (needs vhs + mnemos on PATH; demo-mcp also needs claude)
 demo:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ make install
 
 # 2. index a project
 cd ~/work/myproject
-mnemos init                                 # creates ./.mnemos.toml + ./.mnemos/
+mnemos init                                 # creates ./.mnemos/ (mnemos.toml, kb, db, models)
 mnemos ingest docs --collection myproject   # index a directory
 mnemos search "why did we choose this architecture"
 ```
@@ -62,7 +62,7 @@ mnemos search "why did we choose this architecture"
 Then wire it into Claude Code (note the **absolute** `--config` path):
 
 ```bash
-claude mcp add mnemos -- mnemos serve --config /abs/path/to/myproject/.mnemos.toml
+claude mcp add mnemos -- mnemos serve --config /abs/path/to/myproject/.mnemos/mnemos.toml
 ```
 
 Now Claude answers from your project instead of guessing, and shows its source:
@@ -166,13 +166,13 @@ mnemos eval examples/onpage-seo/bundle --semantic    # the hard case → 0.57
 The 60-second path above used `claude mcp add` with an **absolute `--config`** path:
 
 ```bash
-claude mcp add mnemos -- mnemos serve --config /abs/path/to/project/.mnemos.toml
+claude mcp add mnemos -- mnemos serve --config /abs/path/to/project/.mnemos/mnemos.toml
 ```
 
 To share it with the repo, commit it via `.mcp.json` instead:
 
 ```json
-{ "mcpServers": { "mnemos": { "command": "mnemos", "args": ["serve", "--config", "/abs/path/to/project/.mnemos.toml"] } } }
+{ "mcpServers": { "mnemos": { "command": "mnemos", "args": ["serve", "--config", "/abs/path/to/project/.mnemos/mnemos.toml"] } } }
 ```
 
 Verify with `claude mcp list` (should show `mnemos ✓ connected`) and `/mcp` inside
@@ -303,7 +303,7 @@ Run a watcher to reindex on change (incremental; removes deleted files):
 mnemos watch . --collection myproject
 ```
 
-Enable write-back in `.mnemos.toml` so Claude can capture and manage notes:
+Enable write-back in `.mnemos/mnemos.toml` so Claude can capture and manage notes:
 
 ```toml
 [mcp]
@@ -354,7 +354,7 @@ baseline. See [docs/architecture.md](docs/architecture.md#retrieval-evaluation).
 ## Reference
 
 - **[docs/commands.md](docs/commands.md)** — every CLI command and its flags.
-- **[docs/configuration.md](docs/configuration.md)** — the layered `.mnemos.toml`, with all defaults.
+- **[docs/configuration.md](docs/configuration.md)** — the layered `.mnemos/mnemos.toml`, with all defaults.
 - **[docs/paths-and-indexing.md](docs/paths-and-indexing.md)** — how state is located, what gets indexed, where writes land, and the idempotency/URI rules.
 - **[docs/architecture.md](docs/architecture.md)** — design principles and the retrieval-evaluation methodology.
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ It's optional and Claude Code-specific: the server works with any MCP client
 without it. Install it user-wide (all projects):
 
 ```bash
-make install-skill        # copies skills/mnemos-okf -> ~/.claude/skills/
+make install-skill        # copies skills/mnemos-okf -> ~/.claude/skills/ and merges its hooks
 ```
 
 Or place it manually, e.g. project-level for this repo only:
@@ -263,7 +263,7 @@ done (1)
 
 ### Automation with hooks
 
-The skill is advisory: the model decides when to fire each mode. Claude Code hooks make the memory loop deterministic. Merge [`skills/mnemos-okf/hooks/settings.example.json`](skills/mnemos-okf/hooks/settings.example.json) into your `.claude/settings.json` to activate two hooks:
+The skill is advisory: the model decides when to fire each mode. Claude Code hooks make the memory loop deterministic. `make install-skill` (or `make install-hooks` on its own) merges [`skills/mnemos-okf/hooks/settings.example.json`](skills/mnemos-okf/hooks/settings.example.json) into your `~/.claude/settings.json` idempotently, keeping a `.bak`; pass `SKIP_HOOKS=1` to opt out, or merge the file by hand for a project-level `.claude/settings.json`. Two hooks are activated:
 
 | Hook | Matcher | Effect |
 |------|---------|--------|

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ baseline. See [docs/architecture.md](docs/architecture.md#retrieval-evaluation).
 ## Security
 
 - No network, no telemetry; the MCP server is stdio-only.
+- Shipped binaries carry SBOMs (generated with syft) and are signed with cosign (keyless OIDC).
 - Read-only by default. Write-back is opt-in (`allow_write = true`). Destructive operations (forget, move) require a separate opt-in (`allow_delete = true`).
 - All caller-supplied paths are validated by a confinement guard before any disk operation: `..` traversal, absolute paths outside the tree root, symlink escapes, access to `.mnemos/`, and `[security].exclude` globs are all rejected.
 - Captured content is secret-scanned before it is written or indexed.

--- a/README.md
+++ b/README.md
@@ -281,8 +281,9 @@ commands). Note the spelling: `mnemos.search` is the **MCP tool** Claude calls;
 ### Query (read-only, no gate)
 
 - **`mnemos.search`**: ranked, filtered retrieval with citations.
-- **`mnemos.read`**: read a precise chunk (by `chunk_id`) or a whole document (by `uri`).
-- **`mnemos.context`**: top-k results as LLM-ready context blocks (`uri:start-end` → content).
+- **`mnemos.read`**: read a precise chunk (by `chunk_id`) or a whole document (by `uri`). Pass `follow_links: true` to also attach the document's 1-hop link neighbors.
+- **`mnemos.context`**: top-k results as LLM-ready context blocks (`uri:start-end` → content). Pass `follow_links: true` to attach each block document's 1-hop link neighbors.
+- **`mnemos.related`**: the link-graph neighbors of a document, its outbound links and inbound backlinks (1 hop, document-level). Dangling outbound targets are returned with `resolved: false`. Filter with `direction` (outbound/inbound/both) and `limit`.
 - **`mnemos.list`**: walk the OKF tree on disk and annotate each file with index metadata (title, type, tags, collection) plus an `indexed` flag, so both stored and not-yet-indexed files are visible. Filter by `path`, `collection`, `type`, or indexed state.
 
 ### Write (requires `allow_write = true`)

--- a/docs/adr/0005-single-mnemos-dir-anchor.md
+++ b/docs/adr/0005-single-mnemos-dir-anchor.md
@@ -100,6 +100,48 @@ the primary topology when a project anchor is present. `mnemos status` always pr
 the effective `mode`, `mnemos_dir`, `kb` root, and `index.db` path, so "it works but
 on the wrong KB" cannot pass silently.
 
+#### Amendment (2026-07-20): `$CLAUDE_PROJECT_DIR` rung and fail-closed project resolution
+
+The precedence above left a hole for the MCP-server topology. A user-scoped
+registration (`claude mcp add --scope user mnemos -- mnemos serve`, no pinned
+`--config`/`--mnemos-dir`) relies on the cwd walk-up to find the project, but an MCP
+client does not guarantee the server's working directory — so an unpinned `serve` in a
+project without its own `.mnemos` fell through to the **global** KB and silently served
+the wrong project (documented in `.claude/doc/mnemos-10x-efficiency.md` §2.5). The
+current mitigation — an absolute `--config` per repo — is exactly the per-repo friction
+the single-registration model is meant to remove.
+
+Revised precedence (the full chain, `--config` included; new rung 4):
+
+1. `--config <file>`
+2. `--mnemos-dir <dir>`
+3. `$MNEMOS_DIR`
+4. **`$CLAUDE_PROJECT_DIR`** — Claude Code sets this in a spawned MCP server's
+   environment. Resolve within that project (walk up for `.mnemos`, git-bounded) and
+   **fail closed**: if the project has no `.mnemos`, bind to its canonical
+   *uninitialized* location (`$CLAUDE_PROJECT_DIR/.mnemos`) so the absent database
+   surfaces the existing "run `mnemos init`" error, **never** a silent fall-through to
+   the global KB.
+5. project `./.mnemos` from the cwd (walk up, git-bounded)
+6. `~/.mnemos` global default — reached only when **no** project context is signalled
+   (bare CLI invocation with no `$CLAUDE_PROJECT_DIR`); backward-compatible with the
+   existing global-KB deployment.
+
+This refines the "Discovery surprise" consequence below: a bare command in an unrelated
+directory still reaches the global KB, but a *signalled* project session that lacks a
+workspace now fails closed rather than leaking the global one. Pinned flags (rungs 1-3)
+are unchanged, so existing `--mnemos-dir ~/.mnemos` registrations behave exactly as
+before.
+
+**Deferred (own follow-up):** MCP `roots/list` is a more robust project signal than the
+environment variable, but the client answers it only inside an initialized session —
+after `serve` has already opened the store — so consuming it requires deferring
+workspace resolution and DB binding until post-init. That serve-lifecycle change, and a
+degraded "no workspace" serve mode (serve starts and every tool reports no-workspace,
+rather than the process refusing to start), are tracked as follow-ups to the task
+`tasks/mnemos-p1-workspace-resolution.md`. Implementation landed in
+`internal/workspace/workspace.go` (`Resolve` rung 4) with tests in `workspace_test.go`.
+
 ### 4. Ingestion becomes a managed store
 
 Because every URI resolves from `kb/`, content must live under `kb/`. Ingestion

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,6 +11,7 @@ Every `mnemos` CLI command. Note the spelling split: `mnemos.search` (dot) is th
 | `mnemos ls [path] [--collection --type --tree --depth --all --indexed --unindexed --limit --json]` | List/browse the OKF tree, annotated with index metadata |
 | `mnemos related <uri> [--direction --limit --json]` | List a document's 1-hop link-graph neighbors (outbound links and inbound backlinks) |
 | `mnemos eval <okf-bundle> [--baseline <f> --save --semantic --limit N]` | Retrieval-quality eval on an OKF bundle (`--semantic` evaluates the hybrid retriever) |
+| `mnemos eval <bundle> --graph [--limit K --seed-depth N]` | Graph-answerability eval: reads `<bundle>/cases.json` and measures link-neighborhood inclusion vs plain lexical search (direct hit@K, neighbor inclusion, lift) |
 | `mnemos watch <path> --collection <c>` | Watch and incrementally reindex |
 | `mnemos serve` | Run the MCP server (stdio) |
 | `mnemos status` | Show storage path, counts, and FTS availability |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,7 +11,8 @@ Every `mnemos` CLI command. Note the spelling split: `mnemos.search` (dot) is th
 | `mnemos ls [path] [--collection --type --tree --depth --all --indexed --unindexed --limit --json]` | List/browse the OKF tree, annotated with index metadata |
 | `mnemos related <uri> [--direction --limit --json]` | List a document's 1-hop link-graph neighbors (outbound links and inbound backlinks) |
 | `mnemos eval <okf-bundle> [--baseline <f> --save --semantic --limit N]` | Retrieval-quality eval on an OKF bundle (`--semantic` evaluates the hybrid retriever) |
-| `mnemos eval <bundle> --graph [--limit K --seed-depth N]` | Graph-answerability eval: reads `<bundle>/cases.json` and measures link-neighborhood inclusion vs plain lexical search (direct hit@K, neighbor inclusion, lift) |
+| `mnemos eval <bundle> --graph [--limit K --seed-depth N]` | Graph-answerability eval: reads `<bundle>/cases.json` and measures link-neighborhood inclusion and actual GraphRetriever hit@K vs plain lexical search |
+| `mnemos eval <bundle> --graph-expansion` | Held-out eval with link-neighbor expansion enabled (the Phase 2 non-regression gate: Hit@1/Recall/MRR vs the plain baseline) |
 | `mnemos watch <path> --collection <c>` | Watch and incrementally reindex |
 | `mnemos serve` | Run the MCP server (stdio) |
 | `mnemos status` | Show storage path, counts, and FTS availability |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,6 +9,7 @@ Every `mnemos` CLI command. Note the spelling split: `mnemos.search` (dot) is th
 | `mnemos ingest <path> --collection <c>` | Index a file or directory |
 | `mnemos search <query> [--collection --path --type --since --limit --semantic --json]` | Search the index (`--semantic` fuses lexical + vector; needs the embed build) |
 | `mnemos ls [path] [--collection --type --tree --depth --all --indexed --unindexed --limit --json]` | List/browse the OKF tree, annotated with index metadata |
+| `mnemos related <uri> [--direction --limit --json]` | List a document's 1-hop link-graph neighbors (outbound links and inbound backlinks) |
 | `mnemos eval <okf-bundle> [--baseline <f> --save --semantic --limit N]` | Retrieval-quality eval on an OKF bundle (`--semantic` evaluates the hybrid retriever) |
 | `mnemos watch <path> --collection <c>` | Watch and incrementally reindex |
 | `mnemos serve` | Run the MCP server (stdio) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,9 @@ overlap_tokens = 80
 [search]
 default_limit = 12
 use_vectors = false         # true => hybrid lexical+vector search (needs the embed build + a model)
+graph_expansion = false     # true => fill empty result slots with the top hits' 1-hop link neighbors
+graph_seed_depth = 3        # how many top hits graph expansion pulls neighbors from
+graph_decay = 0.5           # score scale applied to a seed's injected neighbors (0,1]
 
 [mcp]
 transport = "stdio"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,24 +1,25 @@
-# Configuration (`.mnemos.toml`)
+# Configuration (`mnemos.toml`)
 
-Configuration is layered, lowest precedence first:
+mnemos reads a single `mnemos.toml` from the active **MNEMOS_DIR**. The effective
+configuration is the built-in defaults overlaid with that file: each key the file
+sets wins, and every key it omits falls through to the default, so a partial file
+(or no file at all) is fine.
 
-1. **Built-in defaults** (the values shown below).
-2. **`~/.mnemos.toml`**: user-global overrides, applied to every project.
-3. **`./.mnemos.toml`**: the project file in the working directory; its keys win over the home file.
+MNEMOS_DIR is resolved in order: an explicit `--mnemos-dir`, `--config`, or
+`$MNEMOS_DIR`; otherwise the nearest project `.mnemos/` found by walking up from the
+working directory; otherwise the global `~/.mnemos`. The config file is always
+`<MNEMOS_DIR>/mnemos.toml`. Passing `--config <path>` names that file directly, and
+its parent directory becomes the MNEMOS_DIR (and tree root).
 
-Each layer overrides only the keys it sets; everything else falls through to the
-layer below, so a partial file is fine. Passing `--config <path>` **replaces** this
-auto-discovery entirely: only that file is layered on top of the defaults (the home
-and project files are ignored), and its directory becomes the tree root.
+The config carries behaviour only — indexing, chunking, search, the MCP surface,
+and security — never locations: every path (index db, kb, capture, models) is
+derived from MNEMOS_DIR, not configured here.
 
 ```toml
-[storage]
-path = ".mnemos/mnemos.db"
-
 [indexing]
 include = ["**/*.md", "**/*.txt", "**/*.go", "**/*.sql"]
 exclude = [".git/**", "node_modules/**", "vendor/**", "dist/**"]
-max_file_bytes = 4194304    # skip any single file larger than this (0 disables)
+max_file_bytes = 4194304    # skip any single file larger than this (0 disables the cap)
 
 [chunking]
 target_tokens = 700
@@ -26,19 +27,26 @@ overlap_tokens = 80
 
 [search]
 default_limit = 12
+use_vectors = false         # true => hybrid lexical+vector search (needs the embed build + a model)
 
 [mcp]
 transport = "stdio"
-allow_write = false        # gates mnemos.remember
-allow_delete = false       # gates mnemos.forget and mnemos.move
+allow_write = false         # gates mnemos.remember
+allow_delete = false        # gates mnemos.forget and mnemos.move
+result_mode = "text"        # wire shape: "text" | "structured" | "both" (legacy double-emit)
 
 [capture]
-dir = ".mnemos/capture"    # default path for auto-named notes
-defer_to_watcher = false   # true => remember is write-only, watcher ingests
+defer_to_watcher = false    # true => remember is write-only, a running watcher ingests
 
 [security]
 exclude_secrets = true
 exclude = ["**/.env", "**/*.pem", "**/*.key", "**/id_rsa", "**/secrets/**"]
+
+[security.visibility]
+# Collections hidden from every query surface (search, context, read, list, task),
+# enforced server-side. Empty by default. A hidden collection never surfaces even
+# when a caller names it. Example: deny = ["perso", "epfl"]
+deny = []
 ```
 
 See also [commands.md](commands.md) for the CLI reference, and

--- a/examples/graph-answerability/bundle/cases.json
+++ b/examples/graph-answerability/bundle/cases.json
@@ -1,0 +1,30 @@
+{
+  "description": "Graph-answerability cases: each query's lexical match is a hub/overview doc, but the actual answer lives in a linked detail doc written with different vocabulary. Measures whether 1-hop link-graph neighborhood injection surfaces the answer doc that plain lexical search misses. Queries are keyword-style on purpose: the default lexical retriever quotes each token and ANDs them, so a full natural-language question with stopwords (where/how/are) returns nothing. That is itself part of the finding: injection's value is conditional on search finding the hub.",
+  "cases": [
+    {
+      "query": "production deploy",
+      "expected_uri": "runbooks/revert-release.md",
+      "note": "1-hop: deploys/overview.md is the lexical hit and links to the answer"
+    },
+    {
+      "query": "escalation policy",
+      "expected_uri": "policies/paging-tiers.md",
+      "note": "1-hop: oncall/overview.md is the lexical hit and links to the answer"
+    },
+    {
+      "query": "database backups",
+      "expected_uri": "runbooks/snapshot-cron.md",
+      "note": "1-hop: data/overview.md is the lexical hit and links to the answer"
+    },
+    {
+      "query": "secrets stored",
+      "expected_uri": "security/secrets.md",
+      "note": "control: the answer doc is the direct lexical hit, so injection adds no lift here"
+    },
+    {
+      "query": "noisy neighbor",
+      "expected_uri": "runbooks/throttle-tenant.md",
+      "note": "2-hop ceiling: reachable only via overview -> isolation -> runbook, so 1-hop injection is expected to miss it"
+    }
+  ]
+}

--- a/examples/graph-answerability/bundle/data/overview.md
+++ b/examples/graph-answerability/bundle/data/overview.md
@@ -1,0 +1,14 @@
+---
+title: Data Overview
+type: concept
+tags: [database, backup]
+---
+
+# Data Overview
+
+Our databases hold customer records and are backed up on a schedule. How those
+database backups are scheduled and rotated is documented in the
+[snapshot cron runbook](../runbooks/snapshot-cron.md).
+
+This overview does not restate the schedule; refer to the runbook for the actual
+timing and retention.

--- a/examples/graph-answerability/bundle/deploys/overview.md
+++ b/examples/graph-answerability/bundle/deploys/overview.md
@@ -1,0 +1,14 @@
+---
+title: Deploys Overview
+type: concept
+tags: [deploy, production, rollback]
+---
+
+# Deploys Overview
+
+We ship to production continuously. When a bad production deploy happens and you
+need to roll back, do not improvise: the exact recovery steps live in the
+[release revert runbook](../runbooks/revert-release.md).
+
+This page only orients you. It intentionally does not repeat the procedure, so
+there is a single source of truth for how a rollback is actually performed.

--- a/examples/graph-answerability/bundle/index.md
+++ b/examples/graph-answerability/bundle/index.md
@@ -1,0 +1,10 @@
+---
+title: Platform Operations Knowledge Base
+type: index
+---
+
+# Platform Operations
+
+Structure-only index for a small fictional platform-ops vault used to measure
+link-graph neighborhood injection. Sections: deploys, oncall, data, security,
+multitenancy, and the runbooks/policies they point at.

--- a/examples/graph-answerability/bundle/multitenancy/isolation.md
+++ b/examples/graph-answerability/bundle/multitenancy/isolation.md
@@ -1,0 +1,13 @@
+---
+title: Tenant Isolation
+type: concept
+tags: [isolation, quota]
+---
+
+# Tenant Isolation
+
+Isolation is enforced with per-tenant resource quotas and separate connection
+pools. When one tenant exceeds its quota, the concrete mitigation, applying a
+rate limit, is carried out per the [throttle runbook](../runbooks/throttle-tenant.md).
+
+This page covers the design; the runbook covers the hands-on remediation.

--- a/examples/graph-answerability/bundle/multitenancy/overview.md
+++ b/examples/graph-answerability/bundle/multitenancy/overview.md
@@ -1,0 +1,14 @@
+---
+title: Multitenancy Overview
+type: concept
+tags: [multitenancy, tenant, noisy-neighbor]
+---
+
+# Multitenancy Overview
+
+The platform is multi-tenant. A noisy neighbor tenant that consumes more than its
+share can degrade others. The mechanics of keeping tenants apart are described in
+the [tenant isolation](isolation.md) design.
+
+Start there to understand how isolation is enforced before looking at any specific
+mitigation.

--- a/examples/graph-answerability/bundle/oncall/overview.md
+++ b/examples/graph-answerability/bundle/oncall/overview.md
@@ -1,0 +1,14 @@
+---
+title: On-Call Overview
+type: concept
+tags: [oncall, escalation]
+---
+
+# On-Call Overview
+
+Every team keeps an on-call rotation. The escalation policy, who gets contacted
+and how fast, is defined once in the [paging tiers](../policies/paging-tiers.md)
+document.
+
+Use this page to understand that on-call exists and where escalation is governed;
+the concrete windows and responder levels are maintained in that policy.

--- a/examples/graph-answerability/bundle/policies/paging-tiers.md
+++ b/examples/graph-answerability/bundle/policies/paging-tiers.md
@@ -1,0 +1,14 @@
+---
+title: Paging Tiers
+type: policy
+tags: [paging, responders]
+---
+
+# Paging Tiers
+
+- Tier 1 responder: acknowledges within 5 minutes, handles the first response.
+- Tier 2 responder: engaged if Tier 1 does not acknowledge within 10 minutes.
+- Tier 3 (engineering lead): engaged for customer-facing outages after 20 minutes.
+
+Each tier has a primary and a secondary contact in the paging tool. Handoffs
+happen weekly at the Monday sync.

--- a/examples/graph-answerability/bundle/runbooks/revert-release.md
+++ b/examples/graph-answerability/bundle/runbooks/revert-release.md
@@ -1,0 +1,16 @@
+---
+title: Reverting a Release
+type: runbook
+tags: [revert, canary, traffic]
+---
+
+# Reverting a Release
+
+1. Identify the last known-good artifact from the registry.
+2. Pin the service to that previous artifact version.
+3. Shift traffic away from the current canary back to the stable fleet in 10%
+   increments, watching error budgets between steps.
+4. Freeze further changes until the incident channel confirms recovery.
+
+The previous artifact is always retained for at least fourteen days, so this
+recovery path is available even after several subsequent releases.

--- a/examples/graph-answerability/bundle/runbooks/snapshot-cron.md
+++ b/examples/graph-answerability/bundle/runbooks/snapshot-cron.md
@@ -1,0 +1,15 @@
+---
+title: Snapshot Cron
+type: runbook
+tags: [snapshot, retention, cron]
+---
+
+# Snapshot Cron
+
+Snapshots run from a cron entry on the primary node:
+
+- `0 */6 * * *` full snapshot every six hours to object storage.
+- `*/30 * * * *` incremental delta every thirty minutes.
+
+Retention: hourly deltas kept for two days, six-hourly snapshots for thirty days.
+Verify a restore from the newest snapshot at the start of each month.

--- a/examples/graph-answerability/bundle/runbooks/throttle-tenant.md
+++ b/examples/graph-answerability/bundle/runbooks/throttle-tenant.md
@@ -1,0 +1,15 @@
+---
+title: Throttle Runbook
+type: runbook
+tags: [ratelimit, quota]
+---
+
+# Throttle Runbook
+
+1. Identify the offending workload from the per-quota dashboard.
+2. Apply a temporary rate limit at the ingress for that workload's key.
+3. Notify the workload owner with the observed consumption numbers.
+4. Lift the limit once consumption returns under the agreed quota.
+
+Rate limits applied here are temporary; a persistent offender is escalated to a
+capacity review instead.

--- a/examples/graph-answerability/bundle/security/secrets.md
+++ b/examples/graph-answerability/bundle/security/secrets.md
@@ -1,0 +1,14 @@
+---
+title: Secrets Storage
+type: concept
+tags: [secrets, security]
+---
+
+# Secrets Storage
+
+Application secrets are stored in the managed secrets vault, never in the repo or
+in environment files committed to git. Services read secrets at boot through a
+short-lived token issued by the vault agent.
+
+Rotate a stored secret by writing a new version in the vault; running services
+pick it up on their next lease renewal.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 // Build with a patched toolchain (>= the floor) so locally-built binaries pick
 // up stdlib security fixes; the lower `go` line keeps module consumers on 1.25+.
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/adrg/frontmatter v0.2.0

--- a/internal/cli/eval.go
+++ b/internal/cli/eval.go
@@ -13,12 +13,13 @@ import (
 
 // evalFlags holds the values bound to the eval command's flags.
 type evalFlags struct {
-	baseline  string
-	save      bool
-	limit     int
-	semantic  bool
-	graph     bool
-	seedDepth int
+	baseline       string
+	save           bool
+	limit          int
+	semantic       bool
+	graph          bool
+	seedDepth      int
+	graphExpansion bool
 }
 
 // newEvalCmd builds the `eval <bundle>` command. It runs the OKF held-out
@@ -40,6 +41,7 @@ func newEvalCmd(state *rootState) *cobra.Command {
 	cmd.Flags().BoolVar(&f.semantic, "semantic", false, "evaluate the hybrid retriever (requires -tags embed build and an installed model)")
 	cmd.Flags().BoolVar(&f.graph, "graph", false, "run the graph-answerability eval (reads <bundle>/cases.json; measures link-neighborhood inclusion vs plain search)")
 	cmd.Flags().IntVar(&f.seedDepth, "seed-depth", 0, "in --graph mode, how many top hits to expand neighbors from (default: K)")
+	cmd.Flags().BoolVar(&f.graphExpansion, "graph-expansion", false, "in held-out mode, wrap the retriever with link-neighbor expansion (the Phase 2 non-regression gate)")
 
 	return cmd
 }
@@ -80,13 +82,16 @@ func runEval(cmd *cobra.Command, state *rootState, bundle string, f evalFlags) e
 	}
 
 	opts := eval.Options{
-		Bundle:   bundle,
-		K:        f.limit,
-		Include:  a.Config.Indexing.Include,
-		Exclude:  a.Config.Indexing.Exclude,
-		Chunking: chunk.ConfigFrom(a.Config.Chunking.TargetTokens, a.Config.Chunking.OverlapTokens),
-		Semantic: f.semantic,
-		ModelDir: modelDir,
+		Bundle:         bundle,
+		K:              f.limit,
+		Include:        a.Config.Indexing.Include,
+		Exclude:        a.Config.Indexing.Exclude,
+		Chunking:       chunk.ConfigFrom(a.Config.Chunking.TargetTokens, a.Config.Chunking.OverlapTokens),
+		Semantic:       f.semantic,
+		ModelDir:       modelDir,
+		GraphExpansion: f.graphExpansion,
+		GraphSeedDepth: a.Config.Search.GraphSeedDepth,
+		GraphDecay:     a.Config.Search.GraphDecay,
 	}
 
 	_, err = eval.Report(cmd.Context(), a.Logger, cmd.OutOrStdout(), opts, baselinePath, f.save)

--- a/internal/cli/eval.go
+++ b/internal/cli/eval.go
@@ -13,10 +13,12 @@ import (
 
 // evalFlags holds the values bound to the eval command's flags.
 type evalFlags struct {
-	baseline string
-	save     bool
-	limit    int
-	semantic bool
+	baseline  string
+	save      bool
+	limit     int
+	semantic  bool
+	graph     bool
+	seedDepth int
 }
 
 // newEvalCmd builds the `eval <bundle>` command. It runs the OKF held-out
@@ -34,8 +36,10 @@ func newEvalCmd(state *rootState) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&f.baseline, "baseline", "", "path to baseline.json (default: <bundle>/baseline.json)")
 	cmd.Flags().BoolVar(&f.save, "save", false, "write current metrics to the baseline path")
-	cmd.Flags().IntVar(&f.limit, "limit", 0, "retrieval depth K (default: 12)")
+	cmd.Flags().IntVar(&f.limit, "limit", 0, "retrieval depth K (default: 12; 3 in --graph mode)")
 	cmd.Flags().BoolVar(&f.semantic, "semantic", false, "evaluate the hybrid retriever (requires -tags embed build and an installed model)")
+	cmd.Flags().BoolVar(&f.graph, "graph", false, "run the graph-answerability eval (reads <bundle>/cases.json; measures link-neighborhood inclusion vs plain search)")
+	cmd.Flags().IntVar(&f.seedDepth, "seed-depth", 0, "in --graph mode, how many top hits to expand neighbors from (default: K)")
 
 	return cmd
 }
@@ -43,6 +47,19 @@ func newEvalCmd(state *rootState) *cobra.Command {
 func runEval(cmd *cobra.Command, state *rootState, bundle string, f evalFlags) error {
 	a, err := state.loadApp()
 	if err != nil {
+		return err
+	}
+
+	if f.graph {
+		_, err = eval.ReportGraph(cmd.Context(), a.Logger, cmd.OutOrStdout(), eval.GraphOptions{
+			Bundle:    bundle,
+			K:         f.limit,
+			SeedDepth: f.seedDepth,
+			Include:   a.Config.Indexing.Include,
+			Exclude:   a.Config.Indexing.Exclude,
+			Chunking:  chunk.ConfigFrom(a.Config.Chunking.TargetTokens, a.Config.Chunking.OverlapTokens),
+		})
+
 		return err
 	}
 

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -166,18 +166,19 @@ func writeWorkingSet(ctx context.Context, buf *bytes.Buffer, a *app.App) {
 		}
 	}
 
-	if len(decisions) > 0 {
-		_, _ = fmt.Fprintln(buf, "\n### Recent decisions")
-		for _, d := range decisions {
-			title := d.Title
-			if strings.TrimSpace(title) == "" {
-				title = d.URI
-			}
-			if labelled && d.Collection != "" {
-				_, _ = fmt.Fprintf(buf, "- %s — %s (%s)\n", dash(title), d.Collection, d.URI)
-			} else {
-				_, _ = fmt.Fprintf(buf, "- %s (%s)\n", dash(title), d.URI)
-			}
+	if len(decisions) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(buf, "\n### Recent decisions")
+	for _, d := range decisions {
+		title := d.Title
+		if strings.TrimSpace(title) == "" {
+			title = d.URI
+		}
+		if labelled && d.Collection != "" {
+			_, _ = fmt.Fprintf(buf, "- %s — %s (%s)\n", dash(title), d.Collection, d.URI)
+		} else {
+			_, _ = fmt.Fprintf(buf, "- %s (%s)\n", dash(title), d.URI)
 		}
 	}
 }
@@ -206,12 +207,16 @@ func openTasks(ctx context.Context, a *app.App) []taskItem {
 		}
 		items = append(items, taskItem{URI: d.URI, Collection: d.Collection, Title: title, Status: status})
 	}
-	sort.SliceStable(items, func(i, j int) bool {
-		if items[i].Status != items[j].Status {
-			return items[i].Status == "in_progress"
+	slices.SortStableFunc(items, func(a, b taskItem) int {
+		if a.Status != b.Status {
+			if a.Status == "in_progress" {
+				return -1
+			}
+
+			return 1
 		}
 
-		return items[i].URI < items[j].URI
+		return strings.Compare(a.URI, b.URI)
 	})
 
 	return items
@@ -229,8 +234,8 @@ func recentDecisions(ctx context.Context, a *app.App, limit int) []browse.Entry 
 	if err != nil {
 		return nil
 	}
-	sort.SliceStable(entries, func(i, j int) bool {
-		return entries[i].ModifiedAt > entries[j].ModifiedAt
+	slices.SortStableFunc(entries, func(a, b browse.Entry) int {
+		return strings.Compare(b.ModifiedAt, a.ModifiedAt)
 	})
 	if len(entries) > limit {
 		entries = entries[:limit]
@@ -263,12 +268,12 @@ func hookRecall(cmd *cobra.Command, state *rootState, limit, maxTokens int) stri
 		// visibility denylist to the results.
 		svc := memory.New(a.DB, a.Config, a.TreeRoot(), nil, a.Logger)
 		engine := search.NewEngine(a.DB, a.Logger)
-		results, err := svc.Search(ctx(cmd), engine, search.Query{
+		results, searchErr := svc.Search(ctx(cmd), engine, search.Query{
 			Text:  strings.Join(terms, " "),
 			Limit: limit,
 		})
-		if err != nil || len(results) == 0 {
-			return err
+		if searchErr != nil || len(results) == 0 {
+			return searchErr
 		}
 		_, _ = fmt.Fprintln(&buf, "## mnemos recall (top hits — verify before use)")
 		for i, r := range results {

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -1,0 +1,434 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arhuman/mnemos/internal/app"
+	"github.com/arhuman/mnemos/internal/browse"
+	"github.com/arhuman/mnemos/internal/memory"
+	"github.com/arhuman/mnemos/internal/search"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+// The hook subcommands are the process-per-event entry points a Claude Code
+// settings.json wires to SessionStart and UserPromptSubmit. They replace the
+// former multi-process, jq-dependent shell pipelines (plan §4.1-4.2): one Go
+// process reads the hook JSON from stdin, resolves the workspace, and either
+// injects scoped markdown on stdout or stays completely silent.
+//
+// A hook must never break the session, so every failure mode — no workspace, an
+// absent database, a malformed payload, a query error — resolves to empty output
+// and a zero exit. That is why the RunE functions always return nil and the
+// helpers return "" rather than an error: the shell wrappers no longer need
+// `2>/dev/null || exit 0` to paper over failures, though they keep it as belt
+// and braces.
+const (
+	// charsPerToken is the crude bytes-per-token ratio used to turn a
+	// --max-tokens budget into a character cap. It is deliberately conservative
+	// (real tokenizers average ~4 chars/token for English prose) so the cap errs
+	// toward smaller, never larger, than the requested budget.
+	charsPerToken = 4
+
+	// hookDecisionLimit is how many recent decisions the working set injects.
+	hookDecisionLimit = 5
+
+	// hookRecallMaxPromptChars skips recall for prompts longer than this: a very
+	// long prompt is almost always pasted material (a log, a file, a diff), not a
+	// question worth a memory lookup.
+	hookRecallMaxPromptChars = 2000
+)
+
+// hookInput is the subset of the Claude Code hook JSON payload the subcommands
+// read from stdin. Unknown fields are ignored; a payload that is not JSON at all
+// decodes to the zero value and the caller treats it as "nothing to do".
+type hookInput struct {
+	HookEventName string `json:"hook_event_name"`
+	Source        string `json:"source"`
+	Prompt        string `json:"prompt"`
+	Cwd           string `json:"cwd"`
+}
+
+// newHookCmd builds the `hook` parent and its per-event subcommands. It is
+// read-only (no allow_* gate) and mints nothing; it only reads the index.
+func newHookCmd(state *rootState) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hook",
+		Short: "Claude Code hook entry points (session-start, recall)",
+		Long: "Process-per-event entry points for a Claude Code settings.json. Each reads " +
+			"the hook JSON from stdin, resolves the workspace, injects scoped markdown on " +
+			"stdout, and stays silent (exit 0, no output) when the project has no mnemos " +
+			"workspace or nothing relevant to inject.",
+	}
+	cmd.AddCommand(newHookSessionStartCmd(state))
+	cmd.AddCommand(newHookRecallCmd(state))
+
+	return cmd
+}
+
+// newHookSessionStartCmd builds `hook session-start`: the SessionStart working
+// set. It injects the open tasks and recent decisions of the resolved workspace,
+// capped to --max-tokens, and prints nothing when no workspace resolves.
+func newHookSessionStartCmd(state *rootState) *cobra.Command {
+	var maxTokens int
+	cmd := &cobra.Command{
+		Use:   "session-start",
+		Short: "Inject the scoped working set for a Claude Code SessionStart hook",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if out := hookSessionStart(cmd, state, maxTokens); out != "" {
+				_, _ = io.WriteString(cmd.OutOrStdout(), out)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&maxTokens, "max-tokens", 1500, "approximate cap on injected context size in tokens (0 = uncapped)")
+
+	return cmd
+}
+
+// newHookRecallCmd builds `hook recall`: the UserPromptSubmit lexical recall. It
+// reads the prompt from the hook JSON, extracts salient terms, runs a lexical
+// (never embedding-backed) search, and injects the top hits — or nothing when
+// the prompt is not question-shaped, yields no terms, or matches nothing.
+func newHookRecallCmd(state *rootState) *cobra.Command {
+	var maxTokens, limit int
+	cmd := &cobra.Command{
+		Use:   "recall",
+		Short: "Inject cited recall for a Claude Code UserPromptSubmit hook",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if out := hookRecall(cmd, state, limit, maxTokens); out != "" {
+				_, _ = io.WriteString(cmd.OutOrStdout(), out)
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 3, "maximum number of recalled results")
+	cmd.Flags().IntVar(&maxTokens, "max-tokens", 600, "approximate cap on injected context size in tokens (0 = uncapped)")
+
+	return cmd
+}
+
+// hookSessionStart builds the working-set markdown, or "" when no workspace
+// resolves (absent database), the store cannot open, or there is nothing to
+// inject. Any error is swallowed: a hook stays silent rather than failing.
+func hookSessionStart(cmd *cobra.Command, state *rootState, maxTokens int) string {
+	var buf bytes.Buffer
+	err := withStore(state, false, func(a *app.App) error {
+		writeWorkingSet(cmd.Context(), &buf, a)
+
+		return nil
+	})
+	if err != nil {
+		return ""
+	}
+
+	return capTokens(buf.String(), maxTokens)
+}
+
+// writeWorkingSet appends the working set to buf: open tasks (in_progress/todo
+// only, never done) and the most recent decisions. It writes nothing at all when
+// both are empty, so an initialized-but-quiet workspace injects no noise. When
+// the global store is in scope (§5.2) every line is labelled with its collection
+// so a cross-project working set is not an unattributed pile of slugs.
+func writeWorkingSet(ctx context.Context, buf *bytes.Buffer, a *app.App) {
+	labelled := isGlobalScope(a)
+	tasks := openTasks(ctx, a)
+	decisions := recentDecisions(ctx, a, hookDecisionLimit)
+	if len(tasks) == 0 && len(decisions) == 0 {
+		return
+	}
+
+	_, _ = fmt.Fprintln(buf, "## mnemos working set")
+	if labelled {
+		_, _ = fmt.Fprintf(buf, "_global scope (%s); lines labelled by collection_\n", a.Layout.Source)
+	}
+
+	if len(tasks) > 0 {
+		_, _ = fmt.Fprintln(buf, "\n### Open tasks")
+		for _, t := range tasks {
+			if labelled && t.Collection != "" {
+				_, _ = fmt.Fprintf(buf, "- [%s] %s — %s (%s)\n", t.Status, dash(t.Title), t.Collection, t.URI)
+			} else {
+				_, _ = fmt.Fprintf(buf, "- [%s] %s (%s)\n", t.Status, dash(t.Title), t.URI)
+			}
+		}
+	}
+
+	if len(decisions) > 0 {
+		_, _ = fmt.Fprintln(buf, "\n### Recent decisions")
+		for _, d := range decisions {
+			title := d.Title
+			if strings.TrimSpace(title) == "" {
+				title = d.URI
+			}
+			if labelled && d.Collection != "" {
+				_, _ = fmt.Fprintf(buf, "- %s — %s (%s)\n", dash(title), d.Collection, d.URI)
+			} else {
+				_, _ = fmt.Fprintf(buf, "- %s (%s)\n", dash(title), d.URI)
+			}
+		}
+	}
+}
+
+// openTasks returns the workspace's in_progress and todo Task documents, ordered
+// in_progress first then by uri. The visibility denylist is applied so a hidden
+// collection's tasks never surface into the working set. done/cancelled tasks are
+// dropped: the working set is what is live, not a history.
+func openTasks(ctx context.Context, a *app.App) []taskItem {
+	docs, err := storage.ListDocuments(ctx, a.DB, storage.ListFilter{
+		DocType:            "task",
+		ExcludeCollections: a.Config.HiddenCollections(),
+	})
+	if err != nil {
+		return nil
+	}
+	items := make([]taskItem, 0, len(docs))
+	for _, d := range docs {
+		_, st, title := taskMeta(d.FrontmatterJSON)
+		status := strings.ToLower(strings.TrimSpace(st))
+		if status != "in_progress" && status != "todo" {
+			continue
+		}
+		if strings.TrimSpace(title) == "" {
+			title = d.Title
+		}
+		items = append(items, taskItem{URI: d.URI, Collection: d.Collection, Title: title, Status: status})
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].Status != items[j].Status {
+			return items[i].Status == "in_progress"
+		}
+
+		return items[i].URI < items[j].URI
+	})
+
+	return items
+}
+
+// recentDecisions lists up to limit indexed documents under the decisions/ path,
+// most recently modified first. It goes through the memory service so the
+// visibility denylist applies, mirroring the former `mnemos ls decisions` hook.
+func recentDecisions(ctx context.Context, a *app.App, limit int) []browse.Entry {
+	svc := memory.New(a.DB, a.Config, a.TreeRoot(), nil, a.Logger)
+	entries, err := svc.List(ctx, browse.Options{
+		PathPrefix:  "decisions",
+		IndexedOnly: true,
+	})
+	if err != nil {
+		return nil
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].ModifiedAt > entries[j].ModifiedAt
+	})
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	return entries
+}
+
+// hookRecall builds the recall markdown for a prompt read from stdin, or "" when
+// the prompt is absent/oversized/not question-shaped, yields no salient terms,
+// no workspace resolves, or the search returns nothing.
+func hookRecall(cmd *cobra.Command, state *rootState, limit, maxTokens int) string {
+	raw, err := io.ReadAll(cmd.InOrStdin())
+	if err != nil {
+		return ""
+	}
+	prompt := parsePrompt(raw)
+	if !shouldRecall(prompt) {
+		return ""
+	}
+	terms := salientTerms(prompt)
+	if len(terms) == 0 {
+		return ""
+	}
+
+	var buf bytes.Buffer
+	err = withStore(state, false, func(a *app.App) error {
+		// The lexical engine only: recall runs in the prompt-submit hot path and
+		// must never load the ONNX model. The memory service applies the
+		// visibility denylist to the results.
+		svc := memory.New(a.DB, a.Config, a.TreeRoot(), nil, a.Logger)
+		engine := search.NewEngine(a.DB, a.Logger)
+		results, err := svc.Search(ctx(cmd), engine, search.Query{
+			Text:  strings.Join(terms, " "),
+			Limit: limit,
+		})
+		if err != nil || len(results) == 0 {
+			return err
+		}
+		_, _ = fmt.Fprintln(&buf, "## mnemos recall (top hits — verify before use)")
+		for i, r := range results {
+			_, _ = fmt.Fprintf(&buf, "%d. %s (lines %d-%d)\n", i+1, citation(r), r.StartLine, r.EndLine)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return ""
+	}
+
+	return capTokens(buf.String(), maxTokens)
+}
+
+// ctx returns the command's context, or a background context when none is set
+// (the cobra test harness does not always attach one).
+func ctx(cmd *cobra.Command) context.Context {
+	if c := cmd.Context(); c != nil {
+		return c
+	}
+
+	return context.Background()
+}
+
+// parsePrompt extracts the prompt field from a hook JSON payload. A payload that
+// is not JSON, or carries no prompt, yields "".
+func parsePrompt(raw []byte) string {
+	var in hookInput
+	if json.Unmarshal(raw, &in) != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(in.Prompt)
+}
+
+// shouldRecall gates whether a prompt is worth a memory lookup. It skips empty
+// and oversized (pasted) input, then admits a prompt that either carries a recall
+// cue phrase (the fast path) or is question-shaped. Cues are a fast path, not a
+// requirement, since a scoped one-process lexical query is milliseconds cheap and
+// recall stays silent on no hits regardless.
+func shouldRecall(prompt string) bool {
+	p := strings.TrimSpace(prompt)
+	if p == "" || len(p) > hookRecallMaxPromptChars {
+		return false
+	}
+	if hasCuePhrase(p) {
+		return true
+	}
+
+	return strings.HasSuffix(p, "?")
+}
+
+// recallCues are the phrases that mark a prompt as reaching for prior knowledge,
+// in English and French. They mirror the phrases the former shell hook grepped
+// for; matching is case-insensitive on the lowercased prompt.
+var recallCues = []string{
+	"as we decided", "what was", "what were", "remember when", "why did we",
+	"the usual", "last time", "comme on avait", "c'etait quoi", "c'était quoi",
+	"on avait décidé", "on avait decide",
+}
+
+// hasCuePhrase reports whether prompt contains any recall cue (case-insensitive).
+func hasCuePhrase(prompt string) bool {
+	lower := strings.ToLower(prompt)
+	for _, cue := range recallCues {
+		if strings.Contains(lower, cue) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// salientTerms reduces a prompt to the lowercased content words a lexical query
+// should match on: it tokenizes on non-bareword runes, drops stopwords and very
+// short tokens, deduplicates, and caps the count. Fewer, more salient terms make
+// the engine's implicit-AND match more likely to return hits than the raw
+// sentence would. The cap bounds the AND width for a long prompt.
+func salientTerms(prompt string) []string {
+	const maxTerms = 8
+	fields := strings.FieldsFunc(strings.ToLower(prompt), func(r rune) bool {
+		return !isTermRune(r)
+	})
+	seen := make(map[string]bool, len(fields))
+	terms := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.Trim(f, "-.")
+		if len(f) < 3 || stopwords[f] || seen[f] {
+			continue
+		}
+		seen[f] = true
+		terms = append(terms, f)
+		if len(terms) == maxTerms {
+			break
+		}
+	}
+
+	return terms
+}
+
+// isTermRune reports whether r may appear inside a salient term: letters, digits,
+// the inner-safe bareword characters, and any non-ASCII rune (so accented words
+// survive). It mirrors the search engine's bareword rule so the terms this
+// produces tokenize identically downstream.
+func isTermRune(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		return true
+	case r == '_' || r == '-' || r == '.':
+		return true
+	default:
+		return r > 127
+	}
+}
+
+// stopwords is the set of English and French function words dropped from a
+// recall query. It is intentionally small — enough to strip the words that add
+// nothing to a lexical match without needing IDF statistics.
+var stopwords = map[string]bool{
+	// English
+	"the": true, "and": true, "for": true, "with": true, "was": true, "were": true,
+	"are": true, "did": true, "does": true, "you": true, "our": true, "that": true,
+	"this": true, "these": true, "those": true, "what": true, "when": true,
+	"where": true, "why": true, "how": true, "which": true, "who": true, "them": true,
+	"they": true, "his": true, "her": true, "its": true, "about": true, "into": true,
+	"over": true, "than": true, "not": true, "can": true, "could": true, "would": true,
+	"should": true, "will": true, "have": true, "has": true, "had": true, "get": true,
+	"got": true, "use": true, "used": true, "from": true, "been": true, "being": true,
+	// French
+	"les": true, "des": true, "une": true, "que": true, "qui": true, "quoi": true,
+	"avait": true, "est": true, "sont": true, "pour": true, "dans": true, "sur": true,
+	"avec": true, "comme": true, "cette": true, "ces": true, "son": true, "ses": true,
+	"nous": true, "vous": true, "ils": true, "elle": true, "elles": true, "aux": true,
+	"par": true, "plus": true, "pas": true, "decide": true, "décidé": true,
+}
+
+// isGlobalScope reports whether the resolved workspace is the global default
+// (~/.mnemos) rather than a project workspace. Only then is a working set a mix
+// of projects that warrants per-line collection labelling.
+func isGlobalScope(a *app.App) bool {
+	return strings.HasPrefix(a.Layout.Source, "default")
+}
+
+// capTokens truncates s to an approximate token budget, cutting on a line
+// boundary and appending a marker when it clips. A non-positive budget means no
+// cap. The result is always valid UTF-8.
+func capTokens(s string, maxTokens int) string {
+	if maxTokens <= 0 {
+		return s
+	}
+	limit := maxTokens * charsPerToken
+	if len(s) <= limit {
+		return s
+	}
+	truncated := s[:limit]
+	if i := strings.LastIndexByte(truncated, '\n'); i > 0 {
+		truncated = truncated[:i]
+	}
+	truncated = strings.ToValidUTF8(truncated, "")
+
+	return truncated + "\n_[mnemos: truncated to ~" + strconv.Itoa(maxTokens) + " tokens]_\n"
+}

--- a/internal/cli/hook_internal_test.go
+++ b/internal/cli/hook_internal_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSalientTermsStripsStopwordsAndShortTokens(t *testing.T) {
+	got := salientTerms("Why did we choose staging on the VPS?")
+	// why/did/the are stopwords; "we"/"on" are shorter than 3 runes; the rest are
+	// lowercased content words in first-seen order.
+	require.Equal(t, []string{"choose", "staging", "vps"}, got)
+}
+
+func TestSalientTermsDeduplicatesAndCaps(t *testing.T) {
+	require.Equal(t, []string{"alpha", "beta"}, salientTerms("alpha beta alpha BETA alpha"))
+
+	long := strings.Repeat("aaa bbb ccc ddd eee fff ggg hhh iii jjj ", 1)
+	require.Len(t, salientTerms(long), 8, "capped at maxTerms")
+}
+
+func TestShouldRecall(t *testing.T) {
+	cases := []struct {
+		name   string
+		prompt string
+		want   bool
+	}{
+		{"empty", "   ", false},
+		{"plain imperative", "add a csv export button", false},
+		{"question", "which port does the gateway bind?", true},
+		{"cue phrase", "the usual staging setup please", true},
+		{"french cue", "c'était quoi le port déjà", true},
+		{"oversized paste", strings.Repeat("x", hookRecallMaxPromptChars+1) + "?", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldRecall(tc.prompt))
+		})
+	}
+}
+
+func TestParsePrompt(t *testing.T) {
+	require.Equal(t, "hello there", parsePrompt([]byte(`{"prompt":"  hello there  ","hook_event_name":"UserPromptSubmit"}`)))
+	require.Equal(t, "", parsePrompt([]byte(`not json at all`)))
+	require.Equal(t, "", parsePrompt([]byte(`{"cwd":"/tmp"}`)))
+}
+
+func TestCapTokens(t *testing.T) {
+	small := "line one\nline two\n"
+	require.Equal(t, small, capTokens(small, 100), "under budget is unchanged")
+	require.Equal(t, small, capTokens(small, 0), "zero budget is uncapped")
+
+	big := strings.Repeat("abcd\n", 200) // 1000 bytes
+	out := capTokens(big, 10)            // ~40 char budget
+	require.Less(t, len(out), len(big))
+	require.Contains(t, out, "truncated to ~10 tokens")
+	require.True(t, strings.HasSuffix(strings.TrimRight(out, "\n"), "tokens]_"))
+}

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -1,0 +1,121 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/cli"
+)
+
+// runHook executes the root command with args, feeding stdin, and captures
+// stdout. Hook subcommands read the Claude Code event JSON from stdin, so the
+// plain runCmd helper (no stdin) cannot exercise recall.
+func runHook(t *testing.T, stdin string, args ...string) string {
+	t.Helper()
+	root := cli.NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetIn(strings.NewReader(stdin))
+	root.SetArgs(args)
+	require.NoError(t, root.Execute())
+
+	return out.String()
+}
+
+// seedWorkingSet indexes two open tasks (in_progress, todo), one done task, and
+// one decision document in a fresh local workspace under the current temp dir.
+func seedWorkingSet(t *testing.T) {
+	t.Helper()
+	runCmd(t, "init")
+	seedKB(t, "tasks/live.md", "---\ntype: Task\nstatus: in_progress\ntitle: Wire the gateway\n---\n# Wire the gateway\n\nbody\n")
+	seedKB(t, "tasks/next.md", "---\ntype: Task\nstatus: todo\ntitle: Add CSV export\n---\n# Add CSV export\n\nbody\n")
+	seedKB(t, "tasks/old.md", "---\ntype: Task\nstatus: done\ntitle: Ancient history\n---\n# Ancient history\n\nbody\n")
+	seedKB(t, "decisions/0001-anchor.md", "---\ntype: decision\ntitle: Single MNEMOS_DIR anchor\n---\n# Single MNEMOS_DIR anchor\n\nbody\n")
+	runCmd(t, "ingest", ".", "--collection", "demo")
+}
+
+func TestHookSessionStartInjectsScopedWorkingSet(t *testing.T) {
+	chdir(t, t.TempDir())
+	t.Setenv("CLAUDE_PROJECT_DIR", "") // force cwd resolution to the local workspace
+	seedWorkingSet(t)
+
+	out := runHook(t, "", "hook", "session-start")
+
+	require.Contains(t, out, "## mnemos working set")
+	require.Contains(t, out, "### Open tasks")
+	require.Contains(t, out, "Wire the gateway")
+	require.Contains(t, out, "Add CSV export")
+	require.Contains(t, out, "### Recent decisions")
+	require.Contains(t, out, "Single MNEMOS_DIR anchor")
+	// done tasks are never in the working set.
+	require.NotContains(t, out, "Ancient history")
+	// project scope: no per-collection labelling banner.
+	require.NotContains(t, out, "labelled by collection")
+}
+
+func TestHookSessionStartSilentWithoutWorkspace(t *testing.T) {
+	// A signalled project with no .mnemos resolves fail-closed to an uninitialized
+	// location; the absent database must make the hook stay silent, never dump the
+	// global store.
+	proj := t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", proj)
+	chdir(t, t.TempDir())
+
+	out := runHook(t, "", "hook", "session-start")
+
+	require.Empty(t, out)
+}
+
+func TestHookRecallInjectsHits(t *testing.T) {
+	chdir(t, t.TempDir())
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+	runCmd(t, "init")
+	seedKB(t, "decisions/0002-staging.md",
+		"---\ntype: decision\ntitle: Staging on the VPS\n---\n# Staging on the VPS\n\nWe choose staging on the vps because it is cheap.\n")
+	runCmd(t, "ingest", ".", "--collection", "demo")
+
+	out := runHook(t, `{"prompt":"why did we choose staging on the vps?","hook_event_name":"UserPromptSubmit"}`, "hook", "recall")
+
+	require.Contains(t, out, "## mnemos recall")
+	require.Contains(t, out, "decisions/0002-staging.md")
+}
+
+func TestHookRecallSilentOnNoHits(t *testing.T) {
+	chdir(t, t.TempDir())
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+	runCmd(t, "init")
+	seedKB(t, "decisions/0002-staging.md", "---\ntype: decision\ntitle: Staging\n---\n# Staging\n\nWe choose staging on the vps.\n")
+	runCmd(t, "ingest", ".", "--collection", "demo")
+
+	out := runHook(t, `{"prompt":"what about banana pancakes for breakfast?"}`, "hook", "recall")
+
+	require.Empty(t, out)
+}
+
+func TestHookRecallSilentOnNonQuestion(t *testing.T) {
+	chdir(t, t.TempDir())
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+	runCmd(t, "init")
+	seedKB(t, "decisions/0002-staging.md", "---\ntype: decision\ntitle: Staging\n---\n# Staging\n\nstaging vps notes\n")
+	runCmd(t, "ingest", ".", "--collection", "demo")
+
+	// No cue phrase and not question-shaped: recall must not fire even though the
+	// terms would match.
+	out := runHook(t, `{"prompt":"update the staging vps config"}`, "hook", "recall")
+
+	require.Empty(t, out)
+}
+
+func TestHookRecallSilentWithoutWorkspace(t *testing.T) {
+	proj := t.TempDir()
+	t.Setenv("CLAUDE_PROJECT_DIR", proj)
+	chdir(t, t.TempDir())
+
+	out := runHook(t, `{"prompt":"why did we choose staging on the vps?"}`, "hook", "recall")
+
+	require.Empty(t, out)
+}

--- a/internal/cli/reindex.go
+++ b/internal/cli/reindex.go
@@ -7,52 +7,96 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/arhuman/mnemos/internal/app"
+	"github.com/arhuman/mnemos/internal/chunk"
 	"github.com/arhuman/mnemos/internal/embed"
+	"github.com/arhuman/mnemos/internal/ingest"
 	"github.com/arhuman/mnemos/internal/search"
 )
 
 // reindexFlags holds the values bound to the reindex command's flags.
 type reindexFlags struct {
 	embeddings bool
+	content    bool
 }
 
-// newReindexCmd builds the `reindex` command. Phase 4 supports `--embeddings`:
-// (re)compute and store a vector for every chunk. The default build, compiled
-// without embedding support, prints a clear rebuild message instead of failing.
+// newReindexCmd builds the `reindex` command. `--content` re-parses and rewrites
+// every already-indexed document from its on-disk file (propagating a parser or
+// schema change without editing files); `--embeddings` (re)computes a vector for
+// every chunk. Both may be combined; content runs first so embeddings rebuild on
+// the fresh chunks. The default build, compiled without embedding support, prints
+// a clear message for --embeddings instead of failing.
 func newReindexCmd(state *rootState) *cobra.Command {
 	var f reindexFlags
 	cmd := &cobra.Command{
 		Use:   "reindex",
-		Short: "Recompute derived indexes (currently: embeddings)",
+		Short: "Recompute derived indexes (document content and/or embeddings)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runReindex(cmd, state, f)
 		},
 	}
+	cmd.Flags().BoolVar(&f.content, "content", false, "re-parse and rewrite every indexed document from its file (bypasses the unchanged-file skip)")
 	cmd.Flags().BoolVar(&f.embeddings, "embeddings", false, "recompute and store embedding vectors for all chunks")
 
 	return cmd
 }
 
 func runReindex(cmd *cobra.Command, state *rootState, f reindexFlags) error {
-	if !f.embeddings {
-		return errors.New("reindex: nothing to do (pass --embeddings)")
+	if !f.embeddings && !f.content {
+		return errors.New("reindex: nothing to do (pass --content and/or --embeddings)")
 	}
-	if !embed.Supported {
+	if f.embeddings && !embed.Supported {
 		return fmt.Errorf("reindex --embeddings: %s", noEmbedSupportMsg)
 	}
 
 	return withStore(state, false, func(a *app.App) error {
-		e, err := loadEmbedder()
-		if err != nil {
-			return err
+		// Content first: it rewrites chunks (cascading away their embeddings), so a
+		// combined run must rebuild embeddings on the fresh chunks afterwards.
+		if f.content {
+			if err := reindexContent(cmd, a); err != nil {
+				return err
+			}
 		}
-
-		count, err := search.Reindex(cmd.Context(), a.DB, e, a.Logger)
-		if err != nil {
-			return err
+		if f.embeddings {
+			if err := reindexEmbeddings(cmd, a); err != nil {
+				return err
+			}
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "reindexed %d embedding vectors (model %s)\n", count, e.Model())
 
 		return nil
 	})
+}
+
+// reindexContent re-parses every indexed document from disk and reports the tally.
+func reindexContent(cmd *cobra.Command, a *app.App) error {
+	cfg := chunk.ConfigFrom(a.Config.Chunking.TargetTokens, a.Config.Chunking.OverlapTokens)
+	sum, err := ingest.New(a.DB, a.Logger, ingest.WithMaxFileBytes(a.Config.Indexing.MaxFileBytes)).
+		ReindexContent(cmd.Context(), a.TreeRoot(), cfg)
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "content reindex: %d/%d documents reparsed (%d chunks; %d skipped, %d missing)\n",
+		sum.Reindexed, sum.Documents, sum.Chunks, sum.Skipped, sum.Missing)
+	if sum.Reindexed > 0 {
+		_, _ = fmt.Fprintln(out, "note: rewritten chunks dropped their embeddings; run 'reindex --embeddings' to rebuild them")
+	}
+
+	return nil
+}
+
+// reindexEmbeddings recomputes and stores a vector for every chunk.
+func reindexEmbeddings(cmd *cobra.Command, a *app.App) error {
+	e, err := loadEmbedder()
+	if err != nil {
+		return err
+	}
+
+	count, err := search.Reindex(cmd.Context(), a.DB, e, a.Logger)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "reindexed %d embedding vectors (model %s)\n", count, e.Model())
+
+	return nil
 }

--- a/internal/cli/related.go
+++ b/internal/cli/related.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arhuman/mnemos/internal/app"
+	"github.com/arhuman/mnemos/internal/memory"
+)
+
+// relatedFlags holds the values bound to the related command's flags.
+type relatedFlags struct {
+	direction string
+	limit     int
+	asJSON    bool
+}
+
+// newRelatedCmd builds the `related <uri>` command, which lists the 1-hop
+// link-graph neighbors of a document: outbound links it contains and inbound
+// backlinks that point at it. It is read-only and needs no allow_* gate.
+func newRelatedCmd(state *rootState) *cobra.Command {
+	var f relatedFlags
+	cmd := &cobra.Command{
+		Use:   "related <uri>",
+		Short: "List a document's link-graph neighbors (outbound links and inbound backlinks)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRelated(cmd, state, args[0], f)
+		},
+	}
+	cmd.Flags().StringVar(&f.direction, "direction", "both", "which edges to follow: outbound, inbound, or both")
+	cmd.Flags().IntVar(&f.limit, "limit", 0, "maximum neighbors per direction (0 = default)")
+	cmd.Flags().BoolVar(&f.asJSON, "json", false, "emit the neighborhood as JSON")
+
+	return cmd
+}
+
+func runRelated(cmd *cobra.Command, state *rootState, uri string, f relatedFlags) error {
+	return withStore(state, false, func(a *app.App) error {
+		svc := memory.New(a.DB, a.Config, a.TreeRoot(), nil, a.Logger)
+		res, err := svc.Related(cmd.Context(), uri, memory.Direction(f.direction), f.limit)
+		if err != nil {
+			return err
+		}
+
+		out := cmd.OutOrStdout()
+		if f.asJSON {
+			return writeJSONRelated(out, res)
+		}
+		renderRelated(out, res)
+
+		return nil
+	})
+}
+
+// renderRelated prints a tabular listing of the neighborhood: direction, uri,
+// title, collection, and whether the target is indexed (resolved).
+func renderRelated(out io.Writer, res memory.RelatedResult) {
+	if len(res.Outbound) == 0 && len(res.Inbound) == 0 {
+		_, _ = fmt.Fprintln(out, "no neighbors")
+
+		return
+	}
+	w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "DIRECTION\tURI\tTITLE\tCOLLECTION\tRESOLVED")
+	for _, n := range res.Outbound {
+		writeRelatedRow(w, n)
+	}
+	for _, n := range res.Inbound {
+		writeRelatedRow(w, n)
+	}
+	_ = w.Flush()
+}
+
+func writeRelatedRow(w io.Writer, n memory.RelatedNeighbor) {
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		n.Direction, n.URI, dash(n.Title), dash(n.Collection), yesNo(n.Resolved))
+}
+
+// writeJSONRelated emits the neighborhood as indented JSON for agent consumers,
+// normalizing nil direction slices to empty so both arrays are always present.
+func writeJSONRelated(out io.Writer, res memory.RelatedResult) error {
+	if res.Outbound == nil {
+		res.Outbound = []memory.RelatedNeighbor{}
+	}
+	if res.Inbound == nil {
+		res.Inbound = []memory.RelatedNeighbor{}
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(res); err != nil {
+		return fmt.Errorf("related: encode json: %w", err)
+	}
+
+	return nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -78,6 +78,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newMigrateCmd(state))
 	root.AddCommand(newSearchCmd(state))
 	root.AddCommand(newLsCmd(state))
+	root.AddCommand(newRelatedCmd(state))
 	root.AddCommand(newDoctorCmd(state))
 	root.AddCommand(newEvalCmd(state))
 	root.AddCommand(newServeCmd(state))

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -89,6 +89,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newOkfyCmd(state))
 	root.AddCommand(newValidateCmd(state))
 	root.AddCommand(newTaskCmd(state))
+	root.AddCommand(newHookCmd(state))
 
 	return root
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -87,6 +87,23 @@ func runSearch(cmd *cobra.Command, state *rootState, args []string, f searchFlag
 // installed, prints a warning to stderr and degrades to lexical-only rather than
 // failing, honoring the "useful without embeddings" design principle.
 func buildRetriever(cmd *cobra.Command, a *app.App, semantic bool) (search.Retriever, error) {
+	base, err := buildBaseRetriever(cmd, a, semantic)
+	if err != nil {
+		return nil, err
+	}
+	if a.Config.Search.GraphExpansion {
+		return search.NewGraphRetriever(base, a.DB, a.Config.Search.GraphSeedDepth, a.Config.Search.GraphDecay, a.Logger), nil
+	}
+
+	return base, nil
+}
+
+// buildBaseRetriever returns the lexical or hybrid retriever before any
+// graph-expansion wrapping. Without --semantic it is the lexical FTS engine. With
+// --semantic it fuses lexical and vector retrieval via RRF, degrading to lexical
+// (with a stderr warning) when the binary lacks embedding support or no model is
+// installed, honoring the "useful without embeddings" design principle.
+func buildBaseRetriever(cmd *cobra.Command, a *app.App, semantic bool) (search.Retriever, error) {
 	engine := search.NewEngine(a.DB, a.Logger)
 	if !semantic {
 		return engine, nil

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -24,11 +24,13 @@ const noStatusLabel = "(no status)"
 var statusOrder = []string{"in_progress", "todo", "done"}
 
 // taskItem is one indexed Task document reduced to the fields `task list`
-// renders: its uri (citation), title, and free-form (lowercased) status.
+// renders: its uri (citation), collection, title, and free-form (lowercased)
+// status.
 type taskItem struct {
-	URI    string
-	Title  string
-	Status string
+	URI        string
+	Collection string
+	Title      string
+	Status     string
 }
 
 // taskGroup is the set of tasks that share a status, in display order.
@@ -63,23 +65,32 @@ func newTaskCmd(state *rootState) *cobra.Command {
 
 func runTaskList(cmd *cobra.Command, state *rootState, collection, status string) error {
 	return withStore(state, false, func(a *app.App) error {
-		docs, err := storage.ListDocuments(cmd.Context(), a.DB, storage.ListFilter{Collection: collection})
+		// Type and status are filtered in SQL (json_extract), so this returns only
+		// the Task documents to render rather than every document for a Go-side
+		// scan and per-row JSON decode.
+		docs, err := storage.ListDocuments(cmd.Context(), a.DB, storage.ListFilter{
+			Collection: collection,
+			DocType:    "task",
+			Status:     status,
+		})
 		if err != nil {
 			return err
 		}
 
-		wantStatus := strings.ToLower(strings.TrimSpace(status))
-		var items []taskItem
+		items := make([]taskItem, 0, len(docs))
 		for _, d := range docs {
-			docType, st := taskMeta(d.FrontmatterJSON)
-			if !strings.EqualFold(strings.TrimSpace(docType), "Task") {
-				continue
+			_, st, title := taskMeta(d.FrontmatterJSON)
+			// The document title is authoritative; fall back to the indexed title
+			// (derived from the first heading) only when frontmatter omits it.
+			if strings.TrimSpace(title) == "" {
+				title = d.Title
 			}
-			st = strings.ToLower(strings.TrimSpace(st))
-			if wantStatus != "" && st != wantStatus {
-				continue
-			}
-			items = append(items, taskItem{URI: d.URI, Title: d.Title, Status: st})
+			items = append(items, taskItem{
+				URI:        d.URI,
+				Collection: d.Collection,
+				Title:      title,
+				Status:     strings.ToLower(strings.TrimSpace(st)),
+			})
 		}
 
 		renderTaskGroups(cmd.OutOrStdout(), groupTasks(items))
@@ -88,20 +99,21 @@ func runTaskList(cmd *cobra.Command, state *rootState, collection, status string
 	})
 }
 
-// taskMeta extracts the `type` and `status` fields from a document's stored
-// frontmatter JSON. Missing or malformed frontmatter yields empty values.
-func taskMeta(js string) (docType, status string) {
+// taskMeta extracts the `type`, `status`, and `title` fields from a document's
+// stored frontmatter JSON. Missing or malformed frontmatter yields empty values.
+func taskMeta(js string) (docType, status, title string) {
 	if js == "" {
-		return "", ""
+		return "", "", ""
 	}
 	var m map[string]any
 	if json.Unmarshal([]byte(js), &m) != nil {
-		return "", ""
+		return "", "", ""
 	}
 	docType, _ = m["type"].(string)
 	status, _ = m["status"].(string)
+	title, _ = m["title"].(string)
 
-	return docType, status
+	return docType, status, title
 }
 
 // groupTasks buckets tasks by status and returns the buckets in a fixed order:
@@ -161,7 +173,7 @@ func renderTaskGroups(out io.Writer, groups []taskGroup) {
 		_, _ = fmt.Fprintf(out, "%s (%d)\n", g.Status, len(g.Items))
 		w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
 		for _, it := range g.Items {
-			_, _ = fmt.Fprintf(w, "  %s\t%s\n", it.URI, dash(it.Title))
+			_, _ = fmt.Fprintf(w, "  %s\t%s\t%s\n", it.URI, dash(it.Collection), dash(it.Title))
 		}
 		_ = w.Flush()
 	}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -69,9 +69,10 @@ func runTaskList(cmd *cobra.Command, state *rootState, collection, status string
 		// the Task documents to render rather than every document for a Go-side
 		// scan and per-row JSON decode.
 		docs, err := storage.ListDocuments(cmd.Context(), a.DB, storage.ListFilter{
-			Collection: collection,
-			DocType:    "task",
-			Status:     status,
+			Collection:         collection,
+			DocType:            "task",
+			Status:             status,
+			ExcludeCollections: a.Config.HiddenCollections(),
 		})
 		if err != nil {
 			return err

--- a/internal/cli/task_internal_test.go
+++ b/internal/cli/task_internal_test.go
@@ -46,15 +46,18 @@ func TestGroupTasksEmpty(t *testing.T) {
 }
 
 func TestTaskMeta(t *testing.T) {
-	dt, st := taskMeta(`{"type":"Task","status":"todo"}`)
+	dt, st, ti := taskMeta(`{"type":"Task","status":"todo","title":"First"}`)
 	require.Equal(t, "Task", dt)
 	require.Equal(t, "todo", st)
+	require.Equal(t, "First", ti)
 
-	dt, st = taskMeta(`{"type":"idea"}`)
+	dt, st, ti = taskMeta(`{"type":"idea"}`)
 	require.Equal(t, "idea", dt)
 	require.Equal(t, "", st)
+	require.Equal(t, "", ti)
 
-	dt, st = taskMeta("")
+	dt, st, ti = taskMeta("")
 	require.Equal(t, "", dt)
 	require.Equal(t, "", st)
+	require.Equal(t, "", ti)
 }

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -42,6 +42,25 @@ func TestTaskListGroupsByStatus(t *testing.T) {
 		"in_progress group precedes todo group")
 }
 
+func TestTaskListTitleFromFrontmatterAndCollection(t *testing.T) {
+	chdir(t, t.TempDir())
+	runCmd(t, "init")
+	// The heading ("Placeholder") differs from the frontmatter title so the two
+	// sources are distinguishable in the output.
+	seedKB(t, "task.md", "---\ntype: Task\nstatus: todo\ntitle: Real Title\n---\n# Placeholder\n\nbody\n")
+	// A document with no frontmatter at all: the json_extract type filter must
+	// exclude it without erroring on the empty frontmatter_json.
+	seedKB(t, "plain.md", "just a plain note, no frontmatter\n")
+	runCmd(t, "ingest", ".", "--collection", "demo")
+
+	out := runCmd(t, "task", "list")
+
+	require.Contains(t, out, "Real Title", "title comes from frontmatter")
+	require.NotContains(t, out, "Placeholder", "heading is not used when frontmatter has a title")
+	require.Contains(t, out, "demo", "collection is shown per task")
+	require.NotContains(t, out, "plain.md", "non-task without frontmatter is excluded and does not error")
+}
+
 func TestTaskListStatusFilter(t *testing.T) {
 	chdir(t, t.TempDir())
 	seedTasks(t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,16 @@ type ChunkingConfig struct {
 type SearchConfig struct {
 	DefaultLimit int  `koanf:"default_limit"`
 	UseVectors   bool `koanf:"use_vectors"`
+	// GraphExpansion enables link-neighbor expansion: when a query under-fills the
+	// limit, the top hits' 1-hop link neighbors fill the remaining slots. Off by
+	// default; it never reorders base results, so ranking cannot regress.
+	GraphExpansion bool `koanf:"graph_expansion"`
+	// GraphSeedDepth is how many top hits graph expansion pulls neighbors from
+	// (0 = built-in default).
+	GraphSeedDepth int `koanf:"graph_seed_depth"`
+	// GraphDecay scales a seed's score for its injected neighbors, in (0,1]
+	// (0 = built-in default).
+	GraphDecay float64 `koanf:"graph_decay"`
 }
 
 // MCPConfig configures the MCP server surface.
@@ -111,6 +121,13 @@ overlap_tokens = 80
 [search]
 default_limit = 12
 use_vectors = false
+# Link-neighbor expansion: when a query under-fills the limit, fill the remaining
+# slots with the top hits' 1-hop link neighbors. Off by default; it never reorders
+# base results, so ranking cannot regress. seed_depth = top hits expanded,
+# decay = score scale applied to a seed's neighbors.
+graph_expansion = false
+graph_seed_depth = 3
+graph_decay = 0.5
 
 [mcp]
 transport = "stdio"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,10 +77,21 @@ type CaptureConfig struct {
 	DeferToWatcher bool `koanf:"defer_to_watcher"`
 }
 
-// SecurityConfig configures secret exclusion during ingestion.
+// SecurityConfig configures secret exclusion during ingestion and cross-scope
+// query visibility.
 type SecurityConfig struct {
-	ExcludeSecrets bool     `koanf:"exclude_secrets"`
-	Exclude        []string `koanf:"exclude"`
+	ExcludeSecrets bool             `koanf:"exclude_secrets"`
+	Exclude        []string         `koanf:"exclude"`
+	Visibility     VisibilityConfig `koanf:"visibility"`
+}
+
+// VisibilityConfig lists collections hidden from every query surface. The deny
+// list is enforced server-side in the query layer (search, context, list, task),
+// not merely at display, so a hidden collection can never surface — even if a
+// caller names it explicitly. Empty by default: nothing is hidden until
+// configured, keeping a single-store KB fully visible out of the box.
+type VisibilityConfig struct {
+	Deny []string `koanf:"deny"`
 }
 
 // defaultTOML holds the built-in configuration, identical to the file written by
@@ -121,6 +132,13 @@ exclude = [
   "**/id_rsa",
   "**/secrets/**",
 ]
+
+[security.visibility]
+# Collections hidden from every query surface (search, context, list, task),
+# enforced server-side. Empty by default, so all collections are visible. A hidden
+# collection never surfaces even if a caller names it. Example:
+#   deny = ["perso", "epfl"]
+deny = []
 `
 
 // DefaultTOML returns the canonical default configuration document. `init` uses
@@ -136,6 +154,14 @@ func DefaultTOML() []byte {
 // regardless of whether secrets are also being kept out of the index.
 func (c *Config) ConfinementExclude() []string {
 	return c.Security.Exclude
+}
+
+// HiddenCollections returns the collections hidden from every query surface (the
+// [security].visibility.deny list). Empty by default. The query layer excludes
+// these collections server-side so hidden content never surfaces in
+// search/context/list/task regardless of caller-supplied filters.
+func (c *Config) HiddenCollections() []string {
+	return c.Security.Visibility.Deny
 }
 
 // SecurityExclude returns the indexing-time secret-exclusion globs, gated by

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,9 +134,10 @@ exclude = [
 ]
 
 [security.visibility]
-# Collections hidden from every query surface (search, context, list, task),
+# Collections hidden from every query surface (search, context, read, list, task),
 # enforced server-side. Empty by default, so all collections are visible. A hidden
-# collection never surfaces even if a caller names it. Example:
+# collection never surfaces even if a caller names it (including read by uri or
+# chunk_id, which returns the same not-found as an absent one). Example:
 #   deny = ["perso", "epfl"]
 deny = []
 `
@@ -159,7 +160,7 @@ func (c *Config) ConfinementExclude() []string {
 // HiddenCollections returns the collections hidden from every query surface (the
 // [security].visibility.deny list). Empty by default. The query layer excludes
 // these collections server-side so hidden content never surfaces in
-// search/context/list/task regardless of caller-supplied filters.
+// search/context/read/list/task regardless of caller-supplied filters.
 func (c *Config) HiddenCollections() []string {
 	return c.Security.Visibility.Deny
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,12 @@ type MCPConfig struct {
 	// mnemos.move (and their CLI counterparts). It is distinct from AllowWrite
 	// so capture can be enabled without granting delete/move. Default false.
 	AllowDelete bool `koanf:"allow_delete"`
+	// ResultMode selects how tool responses are placed on the wire: "text"
+	// (default) emits the JSON payload once as a text content block;
+	// "structured" emits it once as structuredContent; "both" emits both (the
+	// legacy double-emit, kept for clients that require structuredContent).
+	// Validated at load time to one of those three values.
+	ResultMode string `koanf:"result_mode"`
 }
 
 // CaptureConfig configures write-back behaviour. The capture location itself is
@@ -99,6 +105,9 @@ use_vectors = false
 transport = "stdio"
 allow_write = false
 allow_delete = false
+# How tool responses are serialized: "text" (default, one JSON text block),
+# "structured" (one structuredContent object), or "both" (legacy double-emit).
+result_mode = "text"
 
 [capture]
 defer_to_watcher = false
@@ -162,5 +171,22 @@ func Load(path string, fileExists func(string) bool) (*Config, error) {
 		return nil, fmt.Errorf("config: unmarshal: %w", err)
 	}
 
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	return &cfg, nil
+}
+
+// validate rejects loaded values the defaults cannot cover for. Only
+// [mcp].result_mode is checked today: an unknown mode would silently degrade the
+// MCP wire shape, so it is caught at load time rather than mishandled at serve.
+func (c *Config) validate() error {
+	switch c.MCP.ResultMode {
+	case "text", "structured", "both":
+	default:
+		return fmt.Errorf("config: invalid [mcp].result_mode %q (want text, structured, or both)", c.MCP.ResultMode)
+	}
+
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,3 +73,26 @@ func TestLoadMalformedFileErrors(t *testing.T) {
 	_, err := config.Load(path, exists)
 	require.Error(t, err)
 }
+
+func TestDefaultResultModeIsText(t *testing.T) {
+	cfg, err := config.Load("", missing)
+	require.NoError(t, err)
+	require.Equal(t, "text", cfg.MCP.ResultMode)
+}
+
+func TestLoadAcceptsValidResultModes(t *testing.T) {
+	for _, mode := range []string{"text", "structured", "both"} {
+		dir := t.TempDir()
+		path := writeFile(t, dir, "mnemos.toml", "[mcp]\nresult_mode = \""+mode+"\"\n")
+		cfg, err := config.Load(path, exists)
+		require.NoError(t, err)
+		require.Equal(t, mode, cfg.MCP.ResultMode)
+	}
+}
+
+func TestLoadRejectsInvalidResultMode(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "mnemos.toml", "[mcp]\nresult_mode = \"xml\"\n")
+	_, err := config.Load(path, exists)
+	require.Error(t, err)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,6 +35,23 @@ func TestDefaultTOMLParsesToDefaults(t *testing.T) {
 	require.Contains(t, cfg.Indexing.Include, "**/*.md")
 }
 
+func TestHiddenCollectionsDefaultsEmpty(t *testing.T) {
+	cfg, err := config.Load("", missing)
+	require.NoError(t, err)
+	require.Empty(t, cfg.HiddenCollections(), "no collection is hidden by default")
+}
+
+func TestHiddenCollectionsFromVisibilityDeny(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "mnemos.toml", `
+[security.visibility]
+deny = ["perso", "epfl"]
+`)
+	cfg, err := config.Load(path, exists)
+	require.NoError(t, err)
+	require.Equal(t, []string{"perso", "epfl"}, cfg.HiddenCollections())
+}
+
 func TestLoadOverlaysFile(t *testing.T) {
 	dir := t.TempDir()
 	path := writeFile(t, dir, "mnemos.toml", `

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -39,6 +39,12 @@ type Options struct {
 	Semantic bool
 	// ModelDir is the embedding model directory used when Semantic is true.
 	ModelDir string
+	// GraphExpansion, when true, wraps the retriever with link-neighbor expansion,
+	// so the held-out metrics measure the effect of Phase 2 (the gate: recall up,
+	// Hit@1/MRR not down). Seed depth / decay default when their fields are unset.
+	GraphExpansion bool
+	GraphSeedDepth int
+	GraphDecay     float64
 }
 
 // Run executes the full held-out evaluation: derive example-query pairs, build a
@@ -129,6 +135,20 @@ func Run(ctx context.Context, logger *slog.Logger, opts Options) (Metrics, error
 // the held-out corpus into the temp database and returns a hybrid retriever, so
 // the same metrics can be recomputed to check semantic beats the FTS baseline.
 func buildRetriever(ctx context.Context, db *sql.DB, logger *slog.Logger, opts Options) (search.Retriever, error) {
+	base, err := buildBaseRetriever(ctx, db, logger, opts)
+	if err != nil {
+		return nil, err
+	}
+	if opts.GraphExpansion {
+		return search.NewGraphRetriever(base, db, opts.GraphSeedDepth, opts.GraphDecay, logger), nil
+	}
+
+	return base, nil
+}
+
+// buildBaseRetriever returns the lexical or hybrid retriever before any
+// graph-expansion wrapping.
+func buildBaseRetriever(ctx context.Context, db *sql.DB, logger *slog.Logger, opts Options) (search.Retriever, error) {
 	engine := search.NewEngine(db, logger)
 	if !opts.Semantic {
 		return engine, nil

--- a/internal/eval/graph.go
+++ b/internal/eval/graph.go
@@ -1,0 +1,314 @@
+package eval
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/arhuman/mnemos/internal/chunk"
+	"github.com/arhuman/mnemos/internal/ingest"
+	"github.com/arhuman/mnemos/internal/model"
+	"github.com/arhuman/mnemos/internal/search"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+// defaultGraphK is the shallow retrieval depth used by the graph-answerability
+// eval. It is deliberately small: the point is to measure whether the answer
+// document is reachable via link neighbors when it is NOT in the top few lexical
+// hits, so a deep K (which on a small bundle returns every document) would make
+// the metric trivially 1.0.
+const defaultGraphK = 3
+
+// GraphCase is one curated graph-answerability example: a natural-language query
+// whose best lexical match is a hub/overview document, and the expected answer
+// document that is reachable from that hub by a link rather than by keywords.
+type GraphCase struct {
+	Query       string `json:"query"`
+	ExpectedURI string `json:"expected_uri"`
+	Note        string `json:"note,omitempty"`
+}
+
+// graphCasesFile is the on-disk shape of a bundle's cases.json.
+type graphCasesFile struct {
+	Description string      `json:"description,omitempty"`
+	Cases       []GraphCase `json:"cases"`
+}
+
+// GraphOptions configures a graph-answerability run. Bundle is the OKF bundle
+// (which must contain a cases.json). K is the lexical retrieval depth used both
+// for the direct-hit measurement and as the seed pool whose neighbors are
+// expanded; SeedDepth caps how many of the top-K hits are expanded. Include /
+// Exclude / Chunking mirror the ingest configuration.
+type GraphOptions struct {
+	Bundle    string
+	K         int
+	SeedDepth int
+	Include   []string
+	Exclude   []string
+	Chunking  chunk.Config
+}
+
+// GraphMetrics holds the graph-answerability scores over all cases. Rates are in
+// [0,1]. DirectHitAtK is what plain lexical search achieves; NeighborInclusion
+// is what read/context neighborhood injection would achieve (the answer is in
+// the top-K OR in the 1-hop neighborhood of the top seeds); Lift is the value
+// injection adds; RecoveredMisses is, of the cases plain search misses, the
+// fraction injection recovers.
+type GraphMetrics struct {
+	N                 int     `json:"n"`
+	K                 int     `json:"k"`
+	SeedDepth         int     `json:"seed_depth"`
+	DirectHitAtK      float64 `json:"direct_hit_at_k"`
+	NeighborInclusion float64 `json:"neighbor_inclusion"`
+	Lift              float64 `json:"lift"`
+	RecoveredMisses   float64 `json:"recovered_misses"`
+}
+
+// GraphCaseResult is the per-case outcome, surfaced so the report and tests can
+// show exactly which cases injection recovered.
+type GraphCaseResult struct {
+	Query       string
+	ExpectedURI string
+	DirectHit   bool
+	Included    bool
+	Seeds       []string
+}
+
+// loadGraphCases reads and validates the bundle's cases.json.
+func loadGraphCases(bundle string) ([]GraphCase, error) {
+	path := filepath.Join(bundle, "cases.json")
+	data, err := os.ReadFile(path) //nolint:gosec // path is <bundle>/cases.json, a caller-provided eval bundle
+	if err != nil {
+		return nil, fmt.Errorf("eval: read cases.json: %w", err)
+	}
+	var f graphCasesFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("eval: parse cases.json: %w", err)
+	}
+	for i, c := range f.Cases {
+		if c.Query == "" || c.ExpectedURI == "" {
+			return nil, fmt.Errorf("eval: cases.json case %d needs both query and expected_uri", i)
+		}
+	}
+
+	return f.Cases, nil
+}
+
+// RunGraphInclusion ingests the bundle as-is (answers stay in place, links
+// captured), runs each curated query through the lexical retriever, and measures
+// whether the expected answer document is found directly (top-K) versus reachable
+// through the 1-hop link neighborhood of the top seeds (what neighborhood
+// injection surfaces). The user's real database is never touched. It returns the
+// aggregate metrics and the per-case results.
+func RunGraphInclusion(ctx context.Context, logger *slog.Logger, opts GraphOptions) (GraphMetrics, []GraphCaseResult, error) {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	k := opts.K
+	if k <= 0 {
+		k = defaultGraphK
+	}
+	seedDepth := opts.SeedDepth
+	if seedDepth <= 0 {
+		seedDepth = k
+	}
+
+	cases, err := loadGraphCases(opts.Bundle)
+	if err != nil {
+		return GraphMetrics{}, nil, err
+	}
+	if len(cases) == 0 {
+		return GraphMetrics{K: k, SeedDepth: seedDepth}, nil, nil
+	}
+
+	db, cleanup, err := ingestBundle(ctx, logger, opts.Bundle, opts.Include, opts.Exclude, opts.Chunking)
+	if err != nil {
+		return GraphMetrics{}, nil, err
+	}
+	defer cleanup()
+
+	retriever := search.NewEngine(db, logger)
+	results := make([]GraphCaseResult, 0, len(cases))
+	for _, c := range cases {
+		hits, err := retriever.Search(ctx, search.Query{Text: c.Query, Limit: k})
+		if err != nil {
+			return GraphMetrics{}, nil, fmt.Errorf("eval: graph search %q: %w", c.Query, err)
+		}
+		results = append(results, evalGraphCase(ctx, db, c, hits, seedDepth))
+	}
+
+	return computeGraph(results, k, seedDepth), results, nil
+}
+
+// evalGraphCase scores one case: whether the expected doc is a direct top-K hit,
+// and whether it is included once the 1-hop neighborhood of the top seedDepth
+// hits is added (the injection view).
+func evalGraphCase(ctx context.Context, db *sql.DB, c GraphCase, hits []model.Result, seedDepth int) GraphCaseResult {
+	topURIs := make(map[string]bool)
+	var seeds []string
+	for _, h := range hits {
+		if !topURIs[h.URI] {
+			if len(seeds) < seedDepth {
+				seeds = append(seeds, h.URI)
+			}
+			topURIs[h.URI] = true
+		}
+	}
+
+	directHit := topURIs[c.ExpectedURI]
+
+	included := directHit
+	if !included {
+		neighbors := neighborhoodURIs(ctx, db, seeds)
+		included = neighbors[c.ExpectedURI]
+	}
+
+	return GraphCaseResult{
+		Query:       c.Query,
+		ExpectedURI: c.ExpectedURI,
+		DirectHit:   directHit,
+		Included:    included,
+		Seeds:       seeds,
+	}
+}
+
+// neighborhoodURIs returns the set of document uris reachable in one hop
+// (outbound or inbound) from any seed uri. This is exactly what read/context
+// neighborhood injection would attach to the seed documents.
+func neighborhoodURIs(ctx context.Context, db *sql.DB, seeds []string) map[string]bool {
+	out := make(map[string]bool)
+	for _, s := range seeds {
+		outbound, err := storage.OutboundNeighbors(ctx, db, s)
+		if err != nil {
+			continue
+		}
+		for _, n := range outbound {
+			out[n.URI] = true
+		}
+		inbound, err := storage.InboundNeighbors(ctx, db, s)
+		if err != nil {
+			continue
+		}
+		for _, n := range inbound {
+			out[n.URI] = true
+		}
+	}
+
+	return out
+}
+
+// computeGraph aggregates per-case results into the graph metrics.
+func computeGraph(results []GraphCaseResult, k, seedDepth int) GraphMetrics {
+	m := GraphMetrics{N: len(results), K: k, SeedDepth: seedDepth}
+	if len(results) == 0 {
+		return m
+	}
+	var directHits, included, misses, recovered int
+	for _, r := range results {
+		if r.DirectHit {
+			directHits++
+		} else {
+			misses++
+			if r.Included {
+				recovered++
+			}
+		}
+		if r.Included {
+			included++
+		}
+	}
+	n := float64(len(results))
+	m.DirectHitAtK = float64(directHits) / n
+	m.NeighborInclusion = float64(included) / n
+	m.Lift = m.NeighborInclusion - m.DirectHitAtK
+	if misses > 0 {
+		m.RecoveredMisses = float64(recovered) / float64(misses)
+	}
+
+	return m
+}
+
+// ingestBundle opens an ephemeral migrated database under a temp dir, ingests the
+// whole bundle into it (no held-out stripping, so links are captured intact), and
+// returns the db plus a cleanup that closes it and removes the temp dir.
+func ingestBundle(ctx context.Context, logger *slog.Logger, bundle string, include, exclude []string, chunking chunk.Config) (*sql.DB, func(), error) {
+	work, err := os.MkdirTemp("", "mnemos-grapheval-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("eval: temp dir: %w", err)
+	}
+	cleanupDir := func() { _ = os.RemoveAll(work) }
+
+	db, err := storage.Open(ctx, filepath.Join(work, "grapheval.db"))
+	if err != nil {
+		cleanupDir()
+
+		return nil, nil, fmt.Errorf("eval: open temp db: %w", err)
+	}
+	if err := storage.Migrate(db); err != nil {
+		_ = db.Close()
+		cleanupDir()
+
+		return nil, nil, fmt.Errorf("eval: migrate temp db: %w", err)
+	}
+
+	pipeline := ingest.New(db, logger)
+	if _, err := pipeline.Run(ctx, ingest.Options{
+		Root:       bundle,
+		Collection: evalCollection,
+		Rules:      ingest.Rules{Include: include, Exclude: exclude},
+		Chunking:   chunking,
+	}); err != nil {
+		_ = db.Close()
+		cleanupDir()
+
+		return nil, nil, fmt.Errorf("eval: ingest bundle: %w", err)
+	}
+
+	return db, func() { _ = db.Close(); cleanupDir() }, nil
+}
+
+// ReportGraph runs a graph-answerability evaluation and renders the metrics plus
+// a per-case breakdown to out. It returns the computed metrics.
+func ReportGraph(ctx context.Context, logger *slog.Logger, out io.Writer, opts GraphOptions) (GraphMetrics, error) {
+	m, cases, err := RunGraphInclusion(ctx, logger, opts)
+	if err != nil {
+		return GraphMetrics{}, err
+	}
+	writeGraphReport(out, m, cases)
+
+	return m, nil
+}
+
+// writeGraphReport prints the aggregate metrics and, beneath them, one line per
+// case showing whether plain search hit it and whether injection included it.
+func writeGraphReport(out io.Writer, m GraphMetrics, cases []GraphCaseResult) {
+	_, _ = fmt.Fprintf(out, "graph-answerability  (N=%d, K=%d, seed_depth=%d)\n", m.N, m.K, m.SeedDepth)
+	_, _ = fmt.Fprintf(out, "  direct hit@K        %.2f  (plain lexical search)\n", m.DirectHitAtK)
+	_, _ = fmt.Fprintf(out, "  neighbor inclusion  %.2f  (search + 1-hop neighborhood)\n", m.NeighborInclusion)
+	_, _ = fmt.Fprintf(out, "  lift                %+.2f  (value added by injection)\n", m.Lift)
+	_, _ = fmt.Fprintf(out, "  recovered misses    %.2f  (of search misses, share injection recovers)\n", m.RecoveredMisses)
+	if len(cases) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(out, "  cases:")
+	for _, c := range cases {
+		_, _ = fmt.Fprintf(out, "    [%s] %s -> %s\n", graphCaseLabel(c), c.Query, c.ExpectedURI)
+	}
+}
+
+// graphCaseLabel classifies a case outcome for the per-case breakdown.
+func graphCaseLabel(c GraphCaseResult) string {
+	switch {
+	case c.DirectHit:
+		return "direct"
+	case c.Included:
+		return "recovered"
+	default:
+		return "missed"
+	}
+}

--- a/internal/eval/graph.go
+++ b/internal/eval/graph.go
@@ -67,6 +67,10 @@ type GraphMetrics struct {
 	NeighborInclusion float64 `json:"neighbor_inclusion"`
 	Lift              float64 `json:"lift"`
 	RecoveredMisses   float64 `json:"recovered_misses"`
+	// GraphHitAtK is the fraction of cases where the actual GraphRetriever (base +
+	// link expansion) returns the expected document in its top-K. It is the real
+	// Phase 2 measurement; NeighborInclusion is the raw-neighborhood proxy above.
+	GraphHitAtK float64 `json:"graph_hit_at_k"`
 }
 
 // GraphCaseResult is the per-case outcome, surfaced so the report and tests can
@@ -76,6 +80,7 @@ type GraphCaseResult struct {
 	ExpectedURI string
 	DirectHit   bool
 	Included    bool
+	GraphHit    bool
 	Seeds       []string
 }
 
@@ -133,16 +138,36 @@ func RunGraphInclusion(ctx context.Context, logger *slog.Logger, opts GraphOptio
 	defer cleanup()
 
 	retriever := search.NewEngine(db, logger)
+	graphRetriever := search.NewGraphRetriever(retriever, db, seedDepth, 0, logger)
 	results := make([]GraphCaseResult, 0, len(cases))
 	for _, c := range cases {
 		hits, err := retriever.Search(ctx, search.Query{Text: c.Query, Limit: k})
 		if err != nil {
 			return GraphMetrics{}, nil, fmt.Errorf("eval: graph search %q: %w", c.Query, err)
 		}
-		results = append(results, evalGraphCase(ctx, db, c, hits, seedDepth))
+		r := evalGraphCase(ctx, db, c, hits, seedDepth)
+
+		graphHits, err := graphRetriever.Search(ctx, search.Query{Text: c.Query, Limit: k})
+		if err != nil {
+			return GraphMetrics{}, nil, fmt.Errorf("eval: graph-retriever search %q: %w", c.Query, err)
+		}
+		r.GraphHit = containsURI(graphHits, c.ExpectedURI)
+
+		results = append(results, r)
 	}
 
 	return computeGraph(results, k, seedDepth), results, nil
+}
+
+// containsURI reports whether any result belongs to uri.
+func containsURI(results []model.Result, uri string) bool {
+	for _, r := range results {
+		if r.URI == uri {
+			return true
+		}
+	}
+
+	return false
 }
 
 // evalGraphCase scores one case: whether the expected doc is a direct top-K hit,
@@ -208,7 +233,7 @@ func computeGraph(results []GraphCaseResult, k, seedDepth int) GraphMetrics {
 	if len(results) == 0 {
 		return m
 	}
-	var directHits, included, misses, recovered int
+	var directHits, included, graphHits, misses, recovered int
 	for _, r := range results {
 		if r.DirectHit {
 			directHits++
@@ -221,10 +246,14 @@ func computeGraph(results []GraphCaseResult, k, seedDepth int) GraphMetrics {
 		if r.Included {
 			included++
 		}
+		if r.GraphHit {
+			graphHits++
+		}
 	}
 	n := float64(len(results))
 	m.DirectHitAtK = float64(directHits) / n
 	m.NeighborInclusion = float64(included) / n
+	m.GraphHitAtK = float64(graphHits) / n
 	m.Lift = m.NeighborInclusion - m.DirectHitAtK
 	if misses > 0 {
 		m.RecoveredMisses = float64(recovered) / float64(misses)
@@ -289,8 +318,9 @@ func ReportGraph(ctx context.Context, logger *slog.Logger, out io.Writer, opts G
 func writeGraphReport(out io.Writer, m GraphMetrics, cases []GraphCaseResult) {
 	_, _ = fmt.Fprintf(out, "graph-answerability  (N=%d, K=%d, seed_depth=%d)\n", m.N, m.K, m.SeedDepth)
 	_, _ = fmt.Fprintf(out, "  direct hit@K        %.2f  (plain lexical search)\n", m.DirectHitAtK)
-	_, _ = fmt.Fprintf(out, "  neighbor inclusion  %.2f  (search + 1-hop neighborhood)\n", m.NeighborInclusion)
-	_, _ = fmt.Fprintf(out, "  lift                %+.2f  (value added by injection)\n", m.Lift)
+	_, _ = fmt.Fprintf(out, "  neighbor inclusion  %.2f  (search + 1-hop neighborhood, proxy)\n", m.NeighborInclusion)
+	_, _ = fmt.Fprintf(out, "  graph hit@K         %.2f  (actual GraphRetriever, base + expansion)\n", m.GraphHitAtK)
+	_, _ = fmt.Fprintf(out, "  lift                %+.2f  (neighbor inclusion over direct hit)\n", m.Lift)
 	_, _ = fmt.Fprintf(out, "  recovered misses    %.2f  (of search misses, share injection recovers)\n", m.RecoveredMisses)
 	if len(cases) == 0 {
 		return

--- a/internal/eval/graph_test.go
+++ b/internal/eval/graph_test.go
@@ -1,0 +1,83 @@
+package eval
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/chunk"
+)
+
+// graphBundle is the shipped graph-answerability bundle, evaluated as the real
+// artifact rather than a private testdata copy.
+func graphBundle() string {
+	return filepath.Join("..", "..", "examples", "graph-answerability", "bundle")
+}
+
+func graphOptions() GraphOptions {
+	return GraphOptions{
+		Bundle:   graphBundle(),
+		Include:  []string{"**/*.md"},
+		Chunking: chunk.Config{TargetTokens: 700, OverlapTokens: 80},
+	}
+}
+
+// TestLoadGraphCases asserts the curated cases parse and carry both fields.
+func TestLoadGraphCases(t *testing.T) {
+	cases, err := loadGraphCases(graphBundle())
+	require.NoError(t, err)
+	require.Len(t, cases, 5)
+	for _, c := range cases {
+		require.NotEmpty(t, c.Query)
+		require.NotEmpty(t, c.ExpectedURI)
+	}
+}
+
+// TestRunGraphInclusionShowsLift is the core measurement: neighborhood injection
+// must recover answer docs that plain lexical search misses, so inclusion beats
+// direct hit. The per-case invariants are structural: the "secrets" case is a
+// direct hit (no lift there), the three 1-hop cases are recovered, and the 2-hop
+// case is the expected ceiling miss for 1-hop injection.
+func TestRunGraphInclusionShowsLift(t *testing.T) {
+	m, results, err := RunGraphInclusion(context.Background(), quietLogger(), graphOptions())
+	require.NoError(t, err)
+
+	require.Equal(t, 5, m.N)
+	require.Equal(t, defaultGraphK, m.K)
+	for _, v := range []float64{m.DirectHitAtK, m.NeighborInclusion, m.RecoveredMisses} {
+		require.GreaterOrEqual(t, v, 0.0)
+		require.LessOrEqual(t, v, 1.0)
+	}
+
+	// The whole point: injection adds value over plain search.
+	require.Greater(t, m.NeighborInclusion, m.DirectHitAtK, "inclusion should beat direct hit")
+	require.Greater(t, m.Lift, 0.0, "injection should lift answerability")
+	require.Greater(t, m.RecoveredMisses, 0.0, "injection should recover some search misses")
+
+	byURI := make(map[string]GraphCaseResult, len(results))
+	for _, r := range results {
+		byURI[r.ExpectedURI] = r
+	}
+
+	// Control: the answer is the direct lexical hit, so injection is not needed.
+	secrets := byURI["security/secrets.md"]
+	require.True(t, secrets.DirectHit, "secrets case should be a direct hit")
+
+	// 1-hop: search misses the answer, injection recovers it.
+	revert := byURI["runbooks/revert-release.md"]
+	require.False(t, revert.DirectHit, "revert answer should not be a direct lexical hit")
+	require.True(t, revert.Included, "revert answer should be recovered via a 1-hop link")
+
+	// 2-hop ceiling: 1-hop injection cannot reach it.
+	throttle := byURI["runbooks/throttle-tenant.md"]
+	require.False(t, throttle.Included, "2-hop answer should be beyond 1-hop injection")
+}
+
+// TestGraphSeedDepthDefaultsToK asserts the seed depth defaults to K when unset.
+func TestGraphSeedDepthDefaultsToK(t *testing.T) {
+	m, _, err := RunGraphInclusion(context.Background(), quietLogger(), graphOptions())
+	require.NoError(t, err)
+	require.Equal(t, m.K, m.SeedDepth)
+}

--- a/internal/eval/graph_test.go
+++ b/internal/eval/graph_test.go
@@ -56,6 +56,10 @@ func TestRunGraphInclusionShowsLift(t *testing.T) {
 	require.Greater(t, m.Lift, 0.0, "injection should lift answerability")
 	require.Greater(t, m.RecoveredMisses, 0.0, "injection should recover some search misses")
 
+	// The actual GraphRetriever must realize the proxy: graph hit@K beats plain
+	// direct hit@K, confirming Phase 2 recovers link-only answers.
+	require.Greater(t, m.GraphHitAtK, m.DirectHitAtK, "graph retriever should beat plain search")
+
 	byURI := make(map[string]GraphCaseResult, len(results))
 	for _, r := range results {
 		byURI[r.ExpectedURI] = r

--- a/internal/ingest/capture.go
+++ b/internal/ingest/capture.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 
 	"github.com/arhuman/mnemos/internal/chunk"
+	"github.com/arhuman/mnemos/internal/parse"
 )
 
 // CaptureInput is the content an agent hands to mnemos.remember, normalized for
@@ -28,6 +29,37 @@ type CaptureInput struct {
 	// Timestamp is the capture time. The program may use time.Now(); only the
 	// eval/workflow scripts are forbidden wall-clock access, not the server.
 	Timestamp time.Time
+}
+
+// PrepareOKF turns a capture into the bytes to write, choosing between preserving
+// an authored document and generating a frontmatter wrapper.
+//
+// When the caller targets an explicit path (hasPath) AND the body already opens
+// with a frontmatter block, the body is preserved verbatim (only a trailing
+// newline is ensured). This is the read-modify-write case for a stateful document
+// — a task state file, status.md, a decision — where the caller's frontmatter
+// (status, priority, title, …) is authoritative. Wrapping it in a second block
+// would shadow those fields behind a generated one that carries only
+// type/tags/timestamp/collection, which is why a remembered task never grouped in
+// `mnemos task list`.
+//
+// Otherwise (an inbox capture with no path, or a path target whose body carries
+// no frontmatter yet) the body is wrapped by RenderOKF. Gating passthrough on
+// hasPath keeps raw inbox notes that merely begin with a `---` thematic break from
+// being mistaken for frontmatter. The returned filename is empty in the
+// passthrough case: it is only consumed for auto-naming, which never happens when
+// a path is targeted.
+func PrepareOKF(in CaptureInput, hasPath bool) (filename string, content []byte) {
+	if hasPath && parse.HasFrontmatter([]byte(in.Body)) {
+		body := in.Body
+		if !strings.HasSuffix(body, "\n") {
+			body += "\n"
+		}
+
+		return "", []byte(body)
+	}
+
+	return RenderOKF(in)
 }
 
 // RenderOKF serializes a capture into an OKF markdown document: a YAML

--- a/internal/ingest/capture_test.go
+++ b/internal/ingest/capture_test.go
@@ -57,6 +57,81 @@ func TestRenderOKFNoTags(t *testing.T) {
 	require.Contains(t, string(content), "tags: []")
 }
 
+func TestPrepareOKFPreservesAuthoredFrontmatter(t *testing.T) {
+	// Read-modify-write of a stateful document: the caller targets a path and the
+	// body already carries frontmatter. PrepareOKF must preserve it verbatim, not
+	// wrap it in a second block that would shadow status/priority/title.
+	authored := "---\n" +
+		"type: task\n" +
+		"title: Fix logout cookie\n" +
+		"status: todo\n" +
+		"priority: high\n" +
+		"---\n\n## Goal\ndo the thing\n"
+
+	filename, content := PrepareOKF(CaptureInput{
+		Type:       "task",
+		Body:       authored,
+		Collection: "mnemos",
+		Timestamp:  time.Now(),
+	}, true)
+
+	require.Empty(t, filename, "authored passthrough returns no auto-name")
+	require.Equal(t, authored, string(content), "content preserved byte-for-byte")
+	require.Equal(t, 2, strings.Count(string(content), "---"), "exactly one frontmatter block")
+
+	var fm struct {
+		Type     string `yaml:"type"`
+		Title    string `yaml:"title"`
+		Status   string `yaml:"status"`
+		Priority string `yaml:"priority"`
+	}
+	_, err := frontmatter.Parse(strings.NewReader(string(content)), &fm)
+	require.NoError(t, err)
+	require.Equal(t, "task", fm.Type)
+	require.Equal(t, "todo", fm.Status)
+	require.Equal(t, "high", fm.Priority)
+	require.Equal(t, "Fix logout cookie", fm.Title)
+}
+
+func TestPrepareOKFAddsTrailingNewline(t *testing.T) {
+	authored := "---\ntype: task\nstatus: todo\n---\n\nbody" // no trailing newline
+
+	_, content := PrepareOKF(CaptureInput{Type: "task", Body: authored, Collection: "mnemos", Timestamp: time.Now()}, true)
+	require.Equal(t, authored+"\n", string(content))
+}
+
+func TestPrepareOKFInboxWrapsEvenWithLeadingDashes(t *testing.T) {
+	// No path (inbox capture): always generate frontmatter, even when the raw body
+	// happens to begin with a `---` thematic break — never mistake it for authored
+	// frontmatter.
+	body := "---\nnot frontmatter, a horizontal rule\n\nsome note\n"
+
+	filename, content := PrepareOKF(CaptureInput{
+		Type:       "idea",
+		Body:       body,
+		Collection: "default",
+		Timestamp:  time.Now(),
+	}, false)
+
+	require.NotEmpty(t, filename, "generated capture is auto-named")
+	require.Contains(t, string(content), "timestamp:", "a frontmatter block was generated")
+	require.NotEqual(t, body, string(content))
+}
+
+func TestPrepareOKFPathWithoutFrontmatterGenerates(t *testing.T) {
+	// A path target whose body carries no frontmatter yet is still wrapped, so it
+	// becomes a valid OKF document rather than a bare body.
+	filename, content := PrepareOKF(CaptureInput{
+		Type:       "task",
+		Body:       "just some text",
+		Collection: "mnemos",
+		Timestamp:  time.Now(),
+	}, true)
+
+	require.NotEmpty(t, filename)
+	require.Contains(t, string(content), "type: task")
+}
+
 func TestWriteCaptureAtomic(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "capture")
 	path, err := WriteCapture(dir, "note.md", []byte("hello\n"))

--- a/internal/ingest/pipeline.go
+++ b/internal/ingest/pipeline.go
@@ -28,6 +28,11 @@ type Options struct {
 	Collection string
 	Rules      Rules
 	Chunking   chunk.Config
+	// Force bypasses the content-hash skip so an unchanged file is re-parsed and
+	// rewritten anyway. It is how a parser or schema change is propagated to
+	// already-indexed documents; the oversize, binary, and unparseable skips still
+	// apply. Off for normal ingest/watch, which stay hash-skip-fast.
+	Force bool
 }
 
 // Rules mirrors the config glob sets that drive file selection.

--- a/internal/ingest/process.go
+++ b/internal/ingest/process.go
@@ -79,14 +79,18 @@ func (p *Pipeline) prepare(ctx context.Context, f scanned, opts Options) (result
 
 	hash := hashContent(content)
 
-	existing, ok, err := storage.DocumentHashByURI(ctx, p.db, f.uri)
-	if err != nil {
-		return result{}, fmt.Errorf("ingest: hash lookup %q: %w", f.uri, err)
-	}
-	if ok && existing == hash {
-		p.logger.Debug("ingest skip unchanged", "uri", f.uri)
+	// Force re-parses even an unchanged file, so skip the hash short-circuit; the
+	// oversize/binary/unparseable skips above still guard the read and parse.
+	if !opts.Force {
+		existing, ok, lookupErr := storage.DocumentHashByURI(ctx, p.db, f.uri)
+		if lookupErr != nil {
+			return result{}, fmt.Errorf("ingest: hash lookup %q: %w", f.uri, lookupErr)
+		}
+		if ok && existing == hash {
+			p.logger.Debug("ingest skip unchanged", "uri", f.uri)
 
-		return result{skip: true}, nil
+			return result{skip: true}, nil
+		}
 	}
 
 	modTime := info.ModTime().UTC().Format(time.RFC3339)

--- a/internal/ingest/reindex_content.go
+++ b/internal/ingest/reindex_content.go
@@ -1,0 +1,75 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/arhuman/mnemos/internal/chunk"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+// ReindexContentSummary reports the outcome of a content reindex.
+type ReindexContentSummary struct {
+	// Documents is how many indexed documents were considered.
+	Documents int
+	// Reindexed is how many were re-parsed and rewritten.
+	Reindexed int
+	// Skipped is how many prepare declined (binary/oversize/unparseable on disk).
+	Skipped int
+	// Missing is how many had no readable backing file (deleted or moved); their
+	// existing index rows are left untouched, not removed.
+	Missing int
+	// Chunks is the total chunks rewritten across reindexed documents.
+	Chunks int
+}
+
+// ReindexContent re-parses and rewrites every already-indexed document from its
+// on-disk file, bypassing the content-hash skip, so a parser or schema change
+// (e.g. a corrected title derivation) propagates to the whole index without
+// editing files. It walks the documents table rather than the filesystem, so each
+// document keeps its stored collection and only indexed documents are touched.
+//
+// A document whose file is gone from disk is left in place with a warning (a
+// content reindex refreshes, it does not reconcile deletions). Rewriting a
+// document's chunks cascades away its stored embeddings (they key on chunk id);
+// callers that use semantic search should run `reindex --embeddings` afterwards.
+func (p *Pipeline) ReindexContent(ctx context.Context, kbRoot string, cfg chunk.Config) (ReindexContentSummary, error) {
+	docs, err := storage.ListDocuments(ctx, p.db, storage.ListFilter{})
+	if err != nil {
+		return ReindexContentSummary{}, fmt.Errorf("ingest: reindex list documents: %w", err)
+	}
+
+	sum := ReindexContentSummary{Documents: len(docs)}
+	for _, d := range docs {
+		if err := ctx.Err(); err != nil {
+			return sum, err
+		}
+		abs := filepath.Join(kbRoot, filepath.FromSlash(d.URI))
+		r, err := p.prepare(ctx, scanned{absPath: abs, uri: d.URI}, Options{
+			Collection: d.Collection,
+			Chunking:   cfg,
+			Force:      true,
+		})
+		if err != nil {
+			// A vanished or unreadable file must not abort the whole pass; leave its
+			// row in place and keep going.
+			p.logger.Warn("reindex skip: file unreadable", "uri", d.URI, "error", err)
+			sum.Missing++
+
+			continue
+		}
+		if r.skip {
+			sum.Skipped++
+
+			continue
+		}
+		if err := p.write(ctx, r); err != nil {
+			return sum, fmt.Errorf("ingest: reindex write %q: %w", d.URI, err)
+		}
+		sum.Reindexed++
+		sum.Chunks += len(r.chunks)
+	}
+
+	return sum, nil
+}

--- a/internal/ingest/reindex_content_test.go
+++ b/internal/ingest/reindex_content_test.go
@@ -1,0 +1,119 @@
+package ingest_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/chunk"
+	"github.com/arhuman/mnemos/internal/ingest"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+var reindexChunking = chunk.Config{TargetTokens: 700, OverlapTokens: 80}
+
+// TestForceReingestsUnchanged proves Options.Force bypasses the content-hash skip:
+// a second run of an unchanged corpus re-ingests every file instead of skipping.
+func TestForceReingestsUnchanged(t *testing.T) {
+	src := t.TempDir()
+	write(t, src, "a.md", "# Title\n\nBody\n")
+	write(t, src, "b.md", "# Other\n\nMore\n")
+
+	db := newDB(t)
+	p := ingest.New(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	opts := ingest.Options{
+		Root:       src,
+		Collection: "c",
+		Rules:      ingest.Rules{Include: []string{"**/*.md"}},
+		Chunking:   reindexChunking,
+	}
+
+	sum, err := p.Run(context.Background(), opts)
+	require.NoError(t, err)
+	require.Equal(t, 2, sum.FilesIngested)
+
+	// Unchanged second run without force skips everything.
+	sum2, err := p.Run(context.Background(), opts)
+	require.NoError(t, err)
+	require.Equal(t, 0, sum2.FilesIngested)
+	require.Equal(t, 2, sum2.FilesSkipped)
+
+	// With force, the same unchanged files are re-ingested.
+	opts.Force = true
+	sum3, err := p.Run(context.Background(), opts)
+	require.NoError(t, err)
+	require.Equal(t, 2, sum3.FilesIngested)
+	require.Equal(t, 0, sum3.FilesSkipped)
+}
+
+// TestReindexContentRefreshesStoredFields proves a content reindex re-parses every
+// indexed document from disk and rewrites its stored fields — even when the file
+// itself is unchanged — by restoring a title that was corrupted in the index.
+func TestReindexContentRefreshesStoredFields(t *testing.T) {
+	src := t.TempDir()
+	write(t, src, "a.md", "---\ntitle: Real Title\n---\n\n## Goal\n\nBody\n")
+
+	db := newDB(t)
+	p := ingest.New(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := context.Background()
+	_, err := p.Run(ctx, ingest.Options{
+		Root:       src,
+		Collection: "c",
+		Rules:      ingest.Rules{Include: []string{"**/*.md"}},
+		Chunking:   reindexChunking,
+	})
+	require.NoError(t, err)
+
+	// Corrupt the stored title to simulate a document indexed before a parser fix.
+	_, err = db.ExecContext(ctx, `UPDATE documents SET title = 'STALE' WHERE uri = 'a.md'`)
+	require.NoError(t, err)
+
+	sum, err := p.ReindexContent(ctx, src, reindexChunking)
+	require.NoError(t, err)
+	require.Equal(t, 1, sum.Documents)
+	require.Equal(t, 1, sum.Reindexed)
+	require.Zero(t, sum.Missing)
+
+	doc, err := storage.GetDocumentByURI(ctx, db, "a.md")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Equal(t, "Real Title", doc.Title, "reindex must rewrite the stored title from the file")
+	require.Equal(t, "c", doc.Collection, "reindex preserves the stored collection")
+}
+
+// TestReindexContentMissingFileIsCounted proves a document whose backing file is
+// gone is reported as missing and left in place, not aborting the pass.
+func TestReindexContentMissingFileIsCounted(t *testing.T) {
+	src := t.TempDir()
+	write(t, src, "a.md", "# A\n\nBody\n")
+	write(t, src, "b.md", "# B\n\nBody\n")
+
+	db := newDB(t)
+	p := ingest.New(db, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx := context.Background()
+	_, err := p.Run(ctx, ingest.Options{
+		Root:       src,
+		Collection: "c",
+		Rules:      ingest.Rules{Include: []string{"**/*.md"}},
+		Chunking:   reindexChunking,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(filepath.Join(src, "b.md")))
+
+	sum, err := p.ReindexContent(ctx, src, reindexChunking)
+	require.NoError(t, err)
+	require.Equal(t, 2, sum.Documents)
+	require.Equal(t, 1, sum.Reindexed)
+	require.Equal(t, 1, sum.Missing)
+
+	// The missing file's row is left in place.
+	doc, err := storage.GetDocumentByURI(ctx, db, "b.md")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+}

--- a/internal/mcp/result_test.go
+++ b/internal/mcp/result_test.go
@@ -1,0 +1,55 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResultModes covers the three wire shapes result() can produce. Out must
+// always be nil (so the SDK emits the result untouched), and each mode sets only
+// the fields it should: text → Content only, structured → StructuredContent only,
+// both → both.
+func TestResultModes(t *testing.T) {
+	type payload struct {
+		N int `json:"n"`
+	}
+
+	cases := []struct {
+		mode           resultMode
+		wantContent    bool
+		wantStructured bool
+	}{
+		{resultText, true, false},
+		{resultStructured, false, true},
+		{resultBoth, true, true},
+		{resultMode(""), true, false}, // zero value behaves as text
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.mode), func(t *testing.T) {
+			s := &Server{resultMode: tc.mode}
+			res, out, err := s.result(payload{N: 7})
+			require.NoError(t, err)
+			require.Nil(t, out, "Out must be nil so the SDK emits the result untouched")
+
+			if tc.wantContent {
+				require.Len(t, res.Content, 1)
+				text, ok := res.Content[0].(*mcpsdk.TextContent)
+				require.True(t, ok, "content block must be text")
+				var got payload
+				require.NoError(t, json.Unmarshal([]byte(text.Text), &got))
+				require.Equal(t, 7, got.N)
+			} else {
+				require.Empty(t, res.Content)
+			}
+
+			if tc.wantStructured {
+				require.NotNil(t, res.StructuredContent)
+			} else {
+				require.Nil(t, res.StructuredContent)
+			}
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -91,6 +91,7 @@ func NewServer(db *sql.DB, retriever search.Retriever, cfg *config.Config, treeR
 	srv.registerRead()
 	srv.registerContext()
 	srv.registerList()
+	srv.registerRelated()
 	if cfg.MCP.AllowWrite {
 		srv.registerRemember()
 		srv.registerOkfy()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,6 +8,8 @@ package mcp
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -21,6 +23,23 @@ import (
 // version is reported to MCP clients in the server Implementation.
 const version = "0.3.0"
 
+// resultMode selects how a tool response is placed on the MCP wire. The zero
+// value ("") behaves as resultText, so a Server built without an explicit mode
+// defaults to text-only.
+type resultMode string
+
+const (
+	// resultText emits the JSON payload once as a text content block and leaves
+	// structuredContent nil. It is the default: it preserves exactly what the
+	// client surfaces to the model today while dropping the redundant copy.
+	resultText resultMode = "text"
+	// resultStructured emits the payload once as structuredContent, no text.
+	resultStructured resultMode = "structured"
+	// resultBoth emits the payload as both text and structuredContent (the legacy
+	// double-emit), for clients that require the structured object.
+	resultBoth resultMode = "both"
+)
+
 // Server is the MCP adapter over the memory service. The same value backs both
 // the stdio serve command and the in-memory test client. Every tool handler is
 // thin: it shapes the request, calls a memory.Service method, and formats the
@@ -32,11 +51,12 @@ const version = "0.3.0"
 // for the registration gates and the handler-level defensive re-checks on
 // destructive tools.
 type Server struct {
-	mcp       *mcpsdk.Server
-	svc       *memory.Service
-	retriever search.Retriever
-	logger    *slog.Logger
-	cfg       *config.Config
+	mcp        *mcpsdk.Server
+	svc        *memory.Service
+	retriever  search.Retriever
+	logger     *slog.Logger
+	cfg        *config.Config
+	resultMode resultMode
 }
 
 // NewServer builds the MCP server and registers the read-only tools. db is the
@@ -59,11 +79,12 @@ func NewServer(db *sql.DB, retriever search.Retriever, cfg *config.Config, treeR
 	}
 
 	srv := &Server{
-		mcp:       mcpsdk.NewServer(&mcpsdk.Implementation{Name: "mnemos", Version: version}, nil),
-		svc:       memory.New(db, cfg, treeRoot, scanner, logger),
-		retriever: retriever,
-		logger:    logger,
-		cfg:       cfg,
+		mcp:        mcpsdk.NewServer(&mcpsdk.Implementation{Name: "mnemos", Version: version}, nil),
+		svc:        memory.New(db, cfg, treeRoot, scanner, logger),
+		retriever:  retriever,
+		logger:     logger,
+		cfg:        cfg,
+		resultMode: resultMode(cfg.MCP.ResultMode),
 	}
 
 	srv.registerSearch()
@@ -95,4 +116,30 @@ func (s *Server) Serve(ctx context.Context, transport mcpsdk.Transport) error {
 // that needs to drive the client side concurrently.
 func (s *Server) Connect(ctx context.Context, transport mcpsdk.Transport) (*mcpsdk.ServerSession, error) {
 	return s.mcp.Connect(ctx, transport, nil)
+}
+
+// result builds the CallToolResult for a successful tool call. It marshals v to
+// JSON once and places it on the wire per the configured mode. All tools return
+// through it as (result, nil, nil): because they are registered with Out=any and
+// advertise no output schema, a nil Out makes the SDK emit this result untouched
+// — no marshal, no text/structuredContent mirroring — so the wire carries the
+// payload exactly once (in text mode) instead of the former double-emit.
+func (s *Server) result(v any) (*mcpsdk.CallToolResult, any, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mcp: marshal result: %w", err)
+	}
+
+	res := &mcpsdk.CallToolResult{}
+	switch s.resultMode {
+	case resultStructured:
+		res.StructuredContent = json.RawMessage(data)
+	case resultBoth:
+		res.StructuredContent = json.RawMessage(data)
+		res.Content = []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}}
+	default: // resultText (and the empty zero value)
+		res.Content = []mcpsdk.Content{&mcpsdk.TextContent{Text: string(data)}}
+	}
+
+	return res, nil, nil
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -141,6 +141,7 @@ func callTool(t *testing.T, cs *mcpsdk.ClientSession, name string, args any, out
 type searchHitJSON struct {
 	Title       string  `json:"title"`
 	URI         string  `json:"uri"`
+	Collection  string  `json:"collection"`
 	HeadingPath string  `json:"heading_path"`
 	StartLine   int     `json:"start_line"`
 	EndLine     int     `json:"end_line"`
@@ -180,7 +181,24 @@ func TestSearchTool(t *testing.T) {
 	require.NotEmpty(t, out.Results)
 	require.Equal(t, "guide.md", out.Results[0].URI)
 	require.Equal(t, "SCIM Guide", out.Results[0].Title)
+	require.Equal(t, "epfl", out.Results[0].Collection, "results carry their collection as provenance")
 	require.NotZero(t, out.Results[0].EndLine)
+}
+
+// TestSearchVisibilityDenyThroughConfig proves the [security].visibility.deny
+// boundary flows end-to-end from config through NewServer into the query layer:
+// denying the corpus's only collection yields no results.
+func TestSearchVisibilityDenyThroughConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Visibility.Deny = []string{"epfl"}
+	cs := connectWith(t, ingestCorpus(t), srvCfg{cfg: cfg})
+
+	var out struct {
+		Results []searchHitJSON `json:"results"`
+	}
+	res := callTool(t, cs, "mnemos.search", map[string]any{"query": "SCIM provisioning Entra"}, &out)
+	require.False(t, res.IsError)
+	require.Empty(t, out.Results, "a hidden collection must not surface through the MCP search tool")
 }
 
 // TestToolResponseTextOnly pins the default wire shape: a successful call emits

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -156,8 +156,11 @@ type citationJSON struct {
 }
 
 type contextBlockJSON struct {
-	Source  string `json:"source"`
-	Content string `json:"content"`
+	Source     string `json:"source"`
+	Title      string `json:"title"`
+	ModifiedAt string `json:"modified_at"`
+	Content    string `json:"content"`
+	Truncated  bool   `json:"truncated"`
 }
 
 type searchRefJSON struct {
@@ -359,7 +362,9 @@ func TestContextBatchPreservesSearchOrder(t *testing.T) {
 	var out struct {
 		Context []contextBlockJSON `json:"context"`
 	}
-	cres := callTool(t, cs, "mnemos.context", map[string]any{"query": query}, &out)
+	// group_by=chunk exercises the flat per-chunk listing this test pins; the
+	// tool's default (group_by=document) is covered by TestContextGroupsByDocument.
+	cres := callTool(t, cs, "mnemos.context", map[string]any{"query": query, "group_by": "chunk"}, &out)
 	require.False(t, cres.IsError)
 
 	// One block per search result, in the same rank order, each with content.
@@ -368,6 +373,34 @@ func TestContextBatchPreservesSearchOrder(t *testing.T) {
 		want := fmt.Sprintf("%s:%d-%d", r.URI, r.StartLine, r.EndLine)
 		require.Equal(t, want, out.Context[i].Source, "block %d source/order mismatch", i)
 		require.NotEmpty(t, out.Context[i].Content, "block %d must carry content", i)
+	}
+}
+
+// TestContextGroupsByDocument pins the tool's default shaping: group_by=document
+// collapses hits to the best chunk per document, so a query that matches several
+// chunks of one file yields a single block for that file rather than one per
+// chunk.
+func TestContextGroupsByDocument(t *testing.T) {
+	db := ingestCorpus(t)
+	cs := connect(t, db)
+
+	const query = "line alpha beta gamma"
+
+	var out struct {
+		Context []contextBlockJSON `json:"context"`
+	}
+	cres := callTool(t, cs, "mnemos.context", map[string]any{"query": query}, &out)
+	require.False(t, cres.IsError)
+	require.NotEmpty(t, out.Context)
+
+	// No document appears twice, and every block carries its full chunk content.
+	seen := make(map[string]bool)
+	for _, b := range out.Context {
+		uri, _, ok := strings.Cut(b.Source, ":")
+		require.True(t, ok, "source %q must be uri:lines", b.Source)
+		require.False(t, seen[uri], "document %q appears in more than one grouped block", uri)
+		seen[uri] = true
+		require.NotEmpty(t, b.Content)
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -118,15 +118,21 @@ func connectWith(t *testing.T, db *sql.DB, sc srvCfg) *mcpsdk.ClientSession {
 	return cs
 }
 
-// callTool invokes name with args and unmarshals the structured result into out.
+// callTool invokes name with args and unmarshals the result into out. The server
+// defaults to text mode, so the payload is a single TextContent block whose JSON
+// carries the response; asserting here that StructuredContent is nil and Content
+// holds exactly one text block means every tool call also proves the wire is not
+// double-emitting.
 func callTool(t *testing.T, cs *mcpsdk.ClientSession, name string, args any, out any) *mcpsdk.CallToolResult {
 	t.Helper()
 	res, err := cs.CallTool(context.Background(), &mcpsdk.CallToolParams{Name: name, Arguments: args})
 	require.NoError(t, err)
 	if out != nil && !res.IsError {
-		b, err := json.Marshal(res.StructuredContent)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(b, out))
+		require.Nil(t, res.StructuredContent, "text mode must not emit structuredContent")
+		require.Len(t, res.Content, 1, "text mode must emit exactly one content block")
+		tc, ok := res.Content[0].(*mcpsdk.TextContent)
+		require.True(t, ok, "the single content block must be text")
+		require.NoError(t, json.Unmarshal([]byte(tc.Text), out))
 	}
 
 	return res
@@ -172,6 +178,25 @@ func TestSearchTool(t *testing.T) {
 	require.Equal(t, "guide.md", out.Results[0].URI)
 	require.Equal(t, "SCIM Guide", out.Results[0].Title)
 	require.NotZero(t, out.Results[0].EndLine)
+}
+
+// TestToolResponseTextOnly pins the default wire shape: a successful call emits
+// the payload exactly once, as a single TextContent block, with no
+// structuredContent copy. This is the regression guard against the former
+// double-emit.
+func TestToolResponseTextOnly(t *testing.T) {
+	cs := connect(t, ingestCorpus(t))
+
+	res, err := cs.CallTool(context.Background(), &mcpsdk.CallToolParams{
+		Name:      "mnemos.search",
+		Arguments: map[string]any{"query": "SCIM provisioning Entra"},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Nil(t, res.StructuredContent, "default text mode must not duplicate the payload as structuredContent")
+	require.Len(t, res.Content, 1, "the payload must be a single content block")
+	_, ok := res.Content[0].(*mcpsdk.TextContent)
+	require.True(t, ok, "the single content block must be text")
 }
 
 // TestSearchToolHonorsFilters proves the path/type filters added for CLI/MCP

--- a/internal/mcp/tools_context.go
+++ b/internal/mcp/tools_context.go
@@ -29,6 +29,7 @@ type contextInput struct {
 type contextBlock struct {
 	Source     string `json:"source"`
 	Title      string `json:"title,omitempty"`
+	Collection string `json:"collection,omitempty"`
 	ModifiedAt string `json:"modified_at,omitempty"`
 	Content    string `json:"content"`
 	Truncated  bool   `json:"truncated,omitempty"`
@@ -74,6 +75,7 @@ func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 		out.Context = append(out.Context, contextBlock{
 			Source:     b.Source,
 			Title:      b.Title,
+			Collection: b.Collection,
 			ModifiedAt: b.ModifiedAt,
 			Content:    b.Content,
 			Truncated:  b.Truncated,

--- a/internal/mcp/tools_context.go
+++ b/internal/mcp/tools_context.go
@@ -5,10 +5,12 @@ import (
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/arhuman/mnemos/internal/memory"
 	"github.com/arhuman/mnemos/internal/search"
 )
 
-// contextInput is the mnemos.context request: the same shape as mnemos.search.
+// contextInput is the mnemos.context request: the mnemos.search filters plus
+// shaping controls (grouping and size budget) specific to the context tool.
 type contextInput struct {
 	Query      string `json:"query"                jsonschema:"the search query"`
 	Collection string `json:"collection,omitempty" jsonschema:"restrict results to this collection"`
@@ -16,13 +18,20 @@ type contextInput struct {
 	Type       string `json:"type,omitempty"       jsonschema:"restrict to a file extension, e.g. md"`
 	Since      string `json:"since,omitempty"      jsonschema:"restrict to documents modified at or after this RFC3339 timestamp"`
 	Limit      int    `json:"limit,omitempty"      jsonschema:"maximum number of context blocks (defaults to the configured search limit)"`
+	GroupBy    string `json:"group_by,omitempty"   jsonschema:"how to group blocks: 'document' (default) returns the best chunk per document with its title; 'chunk' returns every matching chunk"`
+	MaxChars   int    `json:"max_chars,omitempty"  jsonschema:"cap each block's content to this many characters (0 = no limit)"`
+	MaxTokens  int    `json:"max_tokens,omitempty" jsonschema:"cap each block's content to roughly this many tokens (~4 chars each; 0 = no limit)"`
 }
 
 // contextBlock is one retrieved passage ready to inject into an LLM prompt:
-// Source cites it as "uri:start-end" and Content is the full chunk text.
+// Source cites it as "uri:start-end", Title/ModifiedAt label its document, and
+// Content is the chunk text. Truncated is set when a size budget clipped it.
 type contextBlock struct {
-	Source  string `json:"source"`
-	Content string `json:"content"`
+	Source     string `json:"source"`
+	Title      string `json:"title,omitempty"`
+	ModifiedAt string `json:"modified_at,omitempty"`
+	Content    string `json:"content"`
+	Truncated  bool   `json:"truncated,omitempty"`
 }
 
 // contextOutput echoes the query and returns the top-k context blocks.
@@ -41,13 +50,20 @@ func (s *Server) registerContext() {
 }
 
 func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, in contextInput) (*mcpsdk.CallToolResult, any, error) {
-	blocks, err := s.svc.Context(ctx, s.retriever, search.Query{
+	blocks, err := s.svc.ContextWithOptions(ctx, s.retriever, search.Query{
 		Text:          in.Query,
 		Collection:    in.Collection,
 		PathPrefix:    in.Path,
 		FileType:      in.Type,
 		ModifiedSince: in.Since,
 		Limit:         in.Limit,
+	}, memory.ContextOptions{
+		// Grouping and the relevance cliff are the tool's defaults; group_by=chunk
+		// (or none) opts back into the flat per-chunk listing.
+		GroupByDocument: in.GroupBy != "chunk" && in.GroupBy != "none",
+		Cliff:           true,
+		MaxChars:        in.MaxChars,
+		MaxTokens:       in.MaxTokens,
 	})
 	if err != nil {
 		return nil, nil, err
@@ -55,7 +71,13 @@ func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 
 	out := contextOutput{Query: in.Query, Context: make([]contextBlock, 0, len(blocks))}
 	for _, b := range blocks {
-		out.Context = append(out.Context, contextBlock{Source: b.Source, Content: b.Content})
+		out.Context = append(out.Context, contextBlock{
+			Source:     b.Source,
+			Title:      b.Title,
+			ModifiedAt: b.ModifiedAt,
+			Content:    b.Content,
+			Truncated:  b.Truncated,
+		})
 	}
 
 	return s.result(out)

--- a/internal/mcp/tools_context.go
+++ b/internal/mcp/tools_context.go
@@ -12,27 +12,31 @@ import (
 // contextInput is the mnemos.context request: the mnemos.search filters plus
 // shaping controls (grouping and size budget) specific to the context tool.
 type contextInput struct {
-	Query      string `json:"query"                jsonschema:"the search query"`
-	Collection string `json:"collection,omitempty" jsonschema:"restrict results to this collection"`
-	Path       string `json:"path,omitempty"       jsonschema:"restrict to documents whose uri starts with this prefix"`
-	Type       string `json:"type,omitempty"       jsonschema:"restrict to a file extension, e.g. md"`
-	Since      string `json:"since,omitempty"      jsonschema:"restrict to documents modified at or after this RFC3339 timestamp"`
-	Limit      int    `json:"limit,omitempty"      jsonschema:"maximum number of context blocks (defaults to the configured search limit)"`
-	GroupBy    string `json:"group_by,omitempty"   jsonschema:"how to group blocks: 'document' (default) returns the best chunk per document with its title; 'chunk' returns every matching chunk"`
-	MaxChars   int    `json:"max_chars,omitempty"  jsonschema:"cap each block's content to this many characters (0 = no limit)"`
-	MaxTokens  int    `json:"max_tokens,omitempty" jsonschema:"cap each block's content to roughly this many tokens (~4 chars each; 0 = no limit)"`
+	Query         string `json:"query"                    jsonschema:"the search query"`
+	Collection    string `json:"collection,omitempty"     jsonschema:"restrict results to this collection"`
+	Path          string `json:"path,omitempty"           jsonschema:"restrict to documents whose uri starts with this prefix"`
+	Type          string `json:"type,omitempty"           jsonschema:"restrict to a file extension, e.g. md"`
+	Since         string `json:"since,omitempty"          jsonschema:"restrict to documents modified at or after this RFC3339 timestamp"`
+	Limit         int    `json:"limit,omitempty"          jsonschema:"maximum number of context blocks (defaults to the configured search limit)"`
+	GroupBy       string `json:"group_by,omitempty"       jsonschema:"how to group blocks: 'document' (default) returns the best chunk per document with its title; 'chunk' returns every matching chunk"`
+	MaxChars      int    `json:"max_chars,omitempty"      jsonschema:"cap each block's content to this many characters (0 = no limit)"`
+	MaxTokens     int    `json:"max_tokens,omitempty"     jsonschema:"cap each block's content to roughly this many tokens (~4 chars each; 0 = no limit)"`
+	FollowLinks   bool   `json:"follow_links,omitempty"   jsonschema:"also attach each block document's 1-hop link neighbors (outbound links and inbound backlinks)"`
+	LinkLimit     int    `json:"link_limit,omitempty"     jsonschema:"with follow_links, max neighbors per direction (0 = server default)"`
+	LinkDirection string `json:"link_direction,omitempty" jsonschema:"with follow_links, which edges to follow: outbound, inbound, or both (default both)"`
 }
 
 // contextBlock is one retrieved passage ready to inject into an LLM prompt:
 // Source cites it as "uri:start-end", Title/ModifiedAt label its document, and
 // Content is the chunk text. Truncated is set when a size budget clipped it.
 type contextBlock struct {
-	Source     string `json:"source"`
-	Title      string `json:"title,omitempty"`
-	Collection string `json:"collection,omitempty"`
-	ModifiedAt string `json:"modified_at,omitempty"`
-	Content    string `json:"content"`
-	Truncated  bool   `json:"truncated,omitempty"`
+	Source     string            `json:"source"`
+	Title      string            `json:"title,omitempty"`
+	Collection string            `json:"collection,omitempty"`
+	ModifiedAt string            `json:"modified_at,omitempty"`
+	Content    string            `json:"content"`
+	Truncated  bool              `json:"truncated,omitempty"`
+	Neighbors  []relatedNeighbor `json:"neighbors,omitempty"`
 }
 
 // contextOutput echoes the query and returns the top-k context blocks.
@@ -65,6 +69,9 @@ func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 		Cliff:           true,
 		MaxChars:        in.MaxChars,
 		MaxTokens:       in.MaxTokens,
+		FollowLinks:     in.FollowLinks,
+		LinkLimit:       in.LinkLimit,
+		LinkDirection:   memory.Direction(in.LinkDirection),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -72,14 +79,18 @@ func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 
 	out := contextOutput{Query: in.Query, Context: make([]contextBlock, 0, len(blocks))}
 	for _, b := range blocks {
-		out.Context = append(out.Context, contextBlock{
+		block := contextBlock{
 			Source:     b.Source,
 			Title:      b.Title,
 			Collection: b.Collection,
 			ModifiedAt: b.ModifiedAt,
 			Content:    b.Content,
 			Truncated:  b.Truncated,
-		})
+		}
+		if len(b.Neighbors) > 0 {
+			block.Neighbors = toRelatedNeighbors(b.Neighbors)
+		}
+		out.Context = append(out.Context, block)
 	}
 
 	return s.result(out)

--- a/internal/mcp/tools_context.go
+++ b/internal/mcp/tools_context.go
@@ -40,7 +40,7 @@ func (s *Server) registerContext() {
 	}, s.handleContext)
 }
 
-func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, in contextInput) (*mcpsdk.CallToolResult, contextOutput, error) {
+func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, in contextInput) (*mcpsdk.CallToolResult, any, error) {
 	blocks, err := s.svc.Context(ctx, s.retriever, search.Query{
 		Text:          in.Query,
 		Collection:    in.Collection,
@@ -50,7 +50,7 @@ func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 		Limit:         in.Limit,
 	})
 	if err != nil {
-		return nil, contextOutput{}, err
+		return nil, nil, err
 	}
 
 	out := contextOutput{Query: in.Query, Context: make([]contextBlock, 0, len(blocks))}
@@ -58,5 +58,5 @@ func (s *Server) handleContext(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 		out.Context = append(out.Context, contextBlock{Source: b.Source, Content: b.Content})
 	}
 
-	return nil, out, nil
+	return s.result(out)
 }

--- a/internal/mcp/tools_forget.go
+++ b/internal/mcp/tools_forget.go
@@ -30,22 +30,22 @@ func (s *Server) registerForget() {
 	}, s.handleForget)
 }
 
-func (s *Server) handleForget(ctx context.Context, _ *mcpsdk.CallToolRequest, in forgetInput) (*mcpsdk.CallToolResult, forgetOutput, error) {
+func (s *Server) handleForget(ctx context.Context, _ *mcpsdk.CallToolRequest, in forgetInput) (*mcpsdk.CallToolResult, any, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, forgetOutput{}, err
+		return nil, nil, err
 	}
 
 	// Defensive re-check: the tool is only registered when allow_delete is true,
 	// and the service re-checks too, but the handler refuses regardless so the
 	// gate cannot be bypassed.
 	if !s.cfg.MCP.AllowDelete {
-		return nil, forgetOutput{}, errors.New("delete disabled: set [mcp].allow_delete=true")
+		return nil, nil, errors.New("delete disabled: set [mcp].allow_delete=true")
 	}
 
 	res, err := s.svc.Forget(ctx, in.Path)
 	if err != nil {
-		return nil, forgetOutput{}, fmt.Errorf("mcp: %w", err)
+		return nil, nil, fmt.Errorf("mcp: %w", err)
 	}
 
-	return nil, forgetOutput{URI: res.URI, Deleted: res.Deleted}, nil
+	return s.result(forgetOutput{URI: res.URI, Deleted: res.Deleted})
 }

--- a/internal/mcp/tools_list.go
+++ b/internal/mcp/tools_list.go
@@ -37,9 +37,9 @@ func (s *Server) registerList() {
 	}, s.handleList)
 }
 
-func (s *Server) handleList(ctx context.Context, _ *mcpsdk.CallToolRequest, in listInput) (*mcpsdk.CallToolResult, listOutput, error) {
+func (s *Server) handleList(ctx context.Context, _ *mcpsdk.CallToolRequest, in listInput) (*mcpsdk.CallToolResult, any, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, listOutput{}, err
+		return nil, nil, err
 	}
 
 	entries, err := s.svc.List(ctx, browse.Options{
@@ -52,8 +52,8 @@ func (s *Server) handleList(ctx context.Context, _ *mcpsdk.CallToolRequest, in l
 		Limit:         in.Limit,
 	})
 	if err != nil {
-		return nil, listOutput{}, err
+		return nil, nil, err
 	}
 
-	return nil, listOutput{Entries: entries}, nil
+	return s.result(listOutput{Entries: entries})
 }

--- a/internal/mcp/tools_move.go
+++ b/internal/mcp/tools_move.go
@@ -38,21 +38,21 @@ func (s *Server) registerMove() {
 	}, s.handleMove)
 }
 
-func (s *Server) handleMove(ctx context.Context, _ *mcpsdk.CallToolRequest, in moveInput) (*mcpsdk.CallToolResult, moveOutput, error) {
+func (s *Server) handleMove(ctx context.Context, _ *mcpsdk.CallToolRequest, in moveInput) (*mcpsdk.CallToolResult, any, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, moveOutput{}, err
+		return nil, nil, err
 	}
 
 	// Defensive re-check: the tool is only registered when allow_delete is true,
 	// and the service re-checks too, but the handler refuses regardless so the
 	// gate cannot be bypassed.
 	if !s.cfg.MCP.AllowDelete {
-		return nil, moveOutput{}, errors.New("delete disabled: set [mcp].allow_delete=true")
+		return nil, nil, errors.New("delete disabled: set [mcp].allow_delete=true")
 	}
 
 	res, err := s.svc.Move(ctx, in.From, in.To)
 	if err != nil {
-		return nil, moveOutput{}, fmt.Errorf("mcp: %w", err)
+		return nil, nil, fmt.Errorf("mcp: %w", err)
 	}
 
 	mv := res.Result
@@ -61,5 +61,5 @@ func (s *Server) handleMove(ctx context.Context, _ *mcpsdk.CallToolRequest, in m
 		out.DocumentID = mv.Entries[0].DocumentID
 	}
 
-	return nil, out, nil
+	return s.result(out)
 }

--- a/internal/mcp/tools_okfy.go
+++ b/internal/mcp/tools_okfy.go
@@ -39,9 +39,9 @@ func (s *Server) registerOkfy() {
 	}, s.handleOkfy)
 }
 
-func (s *Server) handleOkfy(ctx context.Context, _ *mcpsdk.CallToolRequest, in okfyInput) (*mcpsdk.CallToolResult, okfyOutput, error) {
+func (s *Server) handleOkfy(ctx context.Context, _ *mcpsdk.CallToolRequest, in okfyInput) (*mcpsdk.CallToolResult, any, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, okfyOutput{}, err
+		return nil, nil, err
 	}
 
 	// Defensive re-check: the tool is only registered when allow_write is true,
@@ -49,7 +49,7 @@ func (s *Server) handleOkfy(ctx context.Context, _ *mcpsdk.CallToolRequest, in o
 	// un-gated in the service — the local CLI runs it freely — so the MCP write
 	// gate is enforced here, at the remote boundary.)
 	if !s.cfg.MCP.AllowWrite {
-		return nil, okfyOutput{}, errors.New("write disabled: set [mcp].allow_write=true")
+		return nil, nil, errors.New("write disabled: set [mcp].allow_write=true")
 	}
 
 	res, err := s.svc.Okfy(ctx, memory.OkfyInput{
@@ -61,10 +61,10 @@ func (s *Server) handleOkfy(ctx context.Context, _ *mcpsdk.CallToolRequest, in o
 		Force:      in.Force,
 	})
 	if err != nil {
-		return nil, okfyOutput{}, err
+		return nil, nil, err
 	}
 
 	s.logger.Info("okfy converted file", "source", res.SourceURI, "uri", res.URI, "chunks", res.Chunks)
 
-	return nil, okfyOutput{URI: res.URI, DocumentID: res.DocumentID, Chunks: res.Chunks}, nil
+	return s.result(okfyOutput{URI: res.URI, DocumentID: res.DocumentID, Chunks: res.Chunks})
 }

--- a/internal/mcp/tools_read.go
+++ b/internal/mcp/tools_read.go
@@ -10,10 +10,15 @@ import (
 
 // readInput is the mnemos.read request. Exactly one of URI or ChunkID must be
 // set: URI reconstructs a whole document from its stored chunks, ChunkID returns
-// a single chunk with its citation.
+// a single chunk with its citation. Section/Lines scope a document read to a
+// subset of its chunks; MaxChars/MaxTokens cap the returned content.
 type readInput struct {
-	URI     string `json:"uri,omitempty"      jsonschema:"read a whole document by its uri"`
-	ChunkID string `json:"chunk_id,omitempty" jsonschema:"read a single chunk by its id"`
+	URI       string `json:"uri,omitempty"        jsonschema:"read a whole document by its uri"`
+	ChunkID   string `json:"chunk_id,omitempty"   jsonschema:"read a single chunk by its id"`
+	Section   string `json:"section,omitempty"    jsonschema:"for a uri read, keep only chunks whose heading path contains this text (case-insensitive)"`
+	Lines     string `json:"lines,omitempty"      jsonschema:"for a uri read, keep only chunks overlapping this 1-based inclusive source-line span, e.g. 10-42"`
+	MaxChars  int    `json:"max_chars,omitempty"  jsonschema:"cap the returned content to this many characters (0 = no limit)"`
+	MaxTokens int    `json:"max_tokens,omitempty" jsonschema:"cap the returned content to roughly this many tokens (~4 chars each; 0 = no limit)"`
 }
 
 // citation locates a chunk for an agent: the owning document uri, the heading
@@ -27,12 +32,13 @@ type citation struct {
 
 // readOutput is the mnemos.read response. Content is the chunk text or the
 // reconstructed document body; the metadata fields locate it. Citation is set
-// only for a chunk read.
+// only for a chunk read. Truncated is set when a size budget clipped Content.
 type readOutput struct {
 	URI        string    `json:"uri"`
 	Collection string    `json:"collection"`
 	Title      string    `json:"title"`
 	Content    string    `json:"content"`
+	Truncated  bool      `json:"truncated,omitempty"`
 	Citation   *citation `json:"citation,omitempty"`
 }
 
@@ -49,7 +55,12 @@ func (s *Server) handleRead(ctx context.Context, _ *mcpsdk.CallToolRequest, in r
 		return nil, nil, err
 	}
 
-	res, err := s.svc.ReadOne(ctx, in.URI, in.ChunkID)
+	res, err := s.svc.ReadOneOpts(ctx, in.URI, in.ChunkID, memory.ReadOptions{
+		Section:   in.Section,
+		Lines:     in.Lines,
+		MaxChars:  in.MaxChars,
+		MaxTokens: in.MaxTokens,
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -64,6 +75,7 @@ func toReadOutput(r memory.ReadResult) readOutput {
 		Collection: r.Collection,
 		Title:      r.Title,
 		Content:    r.Content,
+		Truncated:  r.Truncated,
 	}
 	if r.Citation != nil {
 		out.Citation = &citation{

--- a/internal/mcp/tools_read.go
+++ b/internal/mcp/tools_read.go
@@ -13,12 +13,15 @@ import (
 // a single chunk with its citation. Section/Lines scope a document read to a
 // subset of its chunks; MaxChars/MaxTokens cap the returned content.
 type readInput struct {
-	URI       string `json:"uri,omitempty"        jsonschema:"read a whole document by its uri"`
-	ChunkID   string `json:"chunk_id,omitempty"   jsonschema:"read a single chunk by its id"`
-	Section   string `json:"section,omitempty"    jsonschema:"for a uri read, keep only chunks whose heading path contains this text (case-insensitive)"`
-	Lines     string `json:"lines,omitempty"      jsonschema:"for a uri read, keep only chunks overlapping this 1-based inclusive source-line span, e.g. 10-42"`
-	MaxChars  int    `json:"max_chars,omitempty"  jsonschema:"cap the returned content to this many characters (0 = no limit)"`
-	MaxTokens int    `json:"max_tokens,omitempty" jsonschema:"cap the returned content to roughly this many tokens (~4 chars each; 0 = no limit)"`
+	URI           string `json:"uri,omitempty"            jsonschema:"read a whole document by its uri"`
+	ChunkID       string `json:"chunk_id,omitempty"       jsonschema:"read a single chunk by its id"`
+	Section       string `json:"section,omitempty"        jsonschema:"for a uri read, keep only chunks whose heading path contains this text (case-insensitive)"`
+	Lines         string `json:"lines,omitempty"          jsonschema:"for a uri read, keep only chunks overlapping this 1-based inclusive source-line span, e.g. 10-42"`
+	MaxChars      int    `json:"max_chars,omitempty"      jsonschema:"cap the returned content to this many characters (0 = no limit)"`
+	MaxTokens     int    `json:"max_tokens,omitempty"     jsonschema:"cap the returned content to roughly this many tokens (~4 chars each; 0 = no limit)"`
+	FollowLinks   bool   `json:"follow_links,omitempty"   jsonschema:"also return the document's 1-hop link neighbors (outbound links and inbound backlinks)"`
+	LinkLimit     int    `json:"link_limit,omitempty"     jsonschema:"with follow_links, max neighbors per direction (0 = server default)"`
+	LinkDirection string `json:"link_direction,omitempty" jsonschema:"with follow_links, which edges to follow: outbound, inbound, or both (default both)"`
 }
 
 // citation locates a chunk for an agent: the owning document uri, the heading
@@ -34,12 +37,13 @@ type citation struct {
 // reconstructed document body; the metadata fields locate it. Citation is set
 // only for a chunk read. Truncated is set when a size budget clipped Content.
 type readOutput struct {
-	URI        string    `json:"uri"`
-	Collection string    `json:"collection"`
-	Title      string    `json:"title"`
-	Content    string    `json:"content"`
-	Truncated  bool      `json:"truncated,omitempty"`
-	Citation   *citation `json:"citation,omitempty"`
+	URI        string            `json:"uri"`
+	Collection string            `json:"collection"`
+	Title      string            `json:"title"`
+	Content    string            `json:"content"`
+	Truncated  bool              `json:"truncated,omitempty"`
+	Citation   *citation         `json:"citation,omitempty"`
+	Neighbors  []relatedNeighbor `json:"neighbors,omitempty"`
 }
 
 // registerRead wires mnemos.read to the memory service's read accessors.
@@ -56,10 +60,13 @@ func (s *Server) handleRead(ctx context.Context, _ *mcpsdk.CallToolRequest, in r
 	}
 
 	res, err := s.svc.ReadOneOpts(ctx, in.URI, in.ChunkID, memory.ReadOptions{
-		Section:   in.Section,
-		Lines:     in.Lines,
-		MaxChars:  in.MaxChars,
-		MaxTokens: in.MaxTokens,
+		Section:       in.Section,
+		Lines:         in.Lines,
+		MaxChars:      in.MaxChars,
+		MaxTokens:     in.MaxTokens,
+		FollowLinks:   in.FollowLinks,
+		LinkLimit:     in.LinkLimit,
+		LinkDirection: memory.Direction(in.LinkDirection),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -84,6 +91,9 @@ func toReadOutput(r memory.ReadResult) readOutput {
 			StartLine:   r.Citation.StartLine,
 			EndLine:     r.Citation.EndLine,
 		}
+	}
+	if len(r.Neighbors) > 0 {
+		out.Neighbors = toRelatedNeighbors(r.Neighbors)
 	}
 
 	return out

--- a/internal/mcp/tools_read.go
+++ b/internal/mcp/tools_read.go
@@ -44,17 +44,17 @@ func (s *Server) registerRead() {
 	}, s.handleRead)
 }
 
-func (s *Server) handleRead(ctx context.Context, _ *mcpsdk.CallToolRequest, in readInput) (*mcpsdk.CallToolResult, readOutput, error) {
+func (s *Server) handleRead(ctx context.Context, _ *mcpsdk.CallToolRequest, in readInput) (*mcpsdk.CallToolResult, any, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, readOutput{}, err
+		return nil, nil, err
 	}
 
 	res, err := s.svc.ReadOne(ctx, in.URI, in.ChunkID)
 	if err != nil {
-		return nil, readOutput{}, err
+		return nil, nil, err
 	}
 
-	return nil, toReadOutput(res), nil
+	return s.result(toReadOutput(res))
 }
 
 // toReadOutput maps a service ReadResult to the MCP response shape.

--- a/internal/mcp/tools_related.go
+++ b/internal/mcp/tools_related.go
@@ -1,0 +1,83 @@
+package mcp
+
+import (
+	"context"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/arhuman/mnemos/internal/memory"
+)
+
+// relatedInput is the mnemos.related request: the document uri to walk from, the
+// edge direction to follow, and a per-direction cap.
+type relatedInput struct {
+	URI       string `json:"uri"                 jsonschema:"the document uri to find link-graph neighbors of"`
+	Direction string `json:"direction,omitempty" jsonschema:"which edges to follow: outbound, inbound, or both (default both)"`
+	Limit     int    `json:"limit,omitempty"     jsonschema:"maximum neighbors per direction (0 = server default)"`
+}
+
+// relatedNeighbor is one 1-hop neighbor on the wire. Resolved is false for a
+// dangling outbound link (the target uri is not indexed), where title/collection
+// are empty.
+type relatedNeighbor struct {
+	URI        string `json:"uri"`
+	Title      string `json:"title,omitempty"`
+	Collection string `json:"collection,omitempty"`
+	Direction  string `json:"direction"`
+	Resolved   bool   `json:"resolved"`
+}
+
+// relatedOutput is the mnemos.related response: the queried uri and its outbound
+// links and inbound backlinks. Both slices are always present (possibly empty).
+type relatedOutput struct {
+	URI      string            `json:"uri"`
+	Outbound []relatedNeighbor `json:"outbound"`
+	Inbound  []relatedNeighbor `json:"inbound"`
+}
+
+// registerRelated wires mnemos.related to the memory service. It is read-only and
+// needs no allow_* gate.
+func (s *Server) registerRelated() {
+	mcpsdk.AddTool(s.mcp, &mcpsdk.Tool{
+		Name:        "mnemos.related",
+		Description: "List the link-graph neighbors of a document: outbound links it contains and inbound backlinks that point at it (1 hop, document-level).",
+	}, s.handleRelated)
+}
+
+func (s *Server) handleRelated(ctx context.Context, _ *mcpsdk.CallToolRequest, in relatedInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	res, err := s.svc.Related(ctx, in.URI, memory.Direction(in.Direction), in.Limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.result(toRelatedOutput(res))
+}
+
+// toRelatedOutput maps a service RelatedResult to the MCP response shape,
+// normalizing nil slices to empty so the JSON always carries the two arrays.
+func toRelatedOutput(r memory.RelatedResult) relatedOutput {
+	return relatedOutput{
+		URI:      r.URI,
+		Outbound: toRelatedNeighbors(r.Outbound),
+		Inbound:  toRelatedNeighbors(r.Inbound),
+	}
+}
+
+func toRelatedNeighbors(ns []memory.RelatedNeighbor) []relatedNeighbor {
+	out := make([]relatedNeighbor, 0, len(ns))
+	for _, n := range ns {
+		out = append(out, relatedNeighbor{
+			URI:        n.URI,
+			Title:      n.Title,
+			Collection: n.Collection,
+			Direction:  n.Direction,
+			Resolved:   n.Resolved,
+		})
+	}
+
+	return out
+}

--- a/internal/mcp/tools_related_test.go
+++ b/internal/mcp/tools_related_test.go
@@ -1,0 +1,120 @@
+package mcp_test
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/chunk"
+	"github.com/arhuman/mnemos/internal/ingest"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+type relatedNeighborJSON struct {
+	URI        string `json:"uri"`
+	Title      string `json:"title"`
+	Collection string `json:"collection"`
+	Direction  string `json:"direction"`
+	Resolved   bool   `json:"resolved"`
+}
+
+// linkedCorpus ingests a two-document vault where a.md links to b.md and back, so
+// the link table has one edge each way.
+func linkedCorpus(t *testing.T) *sql.DB {
+	t.Helper()
+	src := t.TempDir()
+	mustWrite(t, src, "a.md", "# A\n\nSee [B](b.md).\n")
+	mustWrite(t, src, "b.md", "# B\n\nBack to [A](a.md).\n")
+
+	db, err := storage.Open(context.Background(), filepath.Join(t.TempDir(), "mnemos.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, storage.Migrate(db))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_, err = ingest.New(db, logger).Run(context.Background(), ingest.Options{
+		Root:       src,
+		Collection: "demo",
+		Rules:      ingest.Rules{Include: []string{"**/*.md"}},
+		Chunking:   chunk.Config{TargetTokens: 50, OverlapTokens: 10},
+	})
+	require.NoError(t, err)
+
+	return db
+}
+
+func neighborSet(ns []relatedNeighborJSON) map[string]bool {
+	out := make(map[string]bool, len(ns))
+	for _, n := range ns {
+		out[n.URI] = true
+	}
+
+	return out
+}
+
+func TestRelatedTool(t *testing.T) {
+	cs := connect(t, linkedCorpus(t))
+
+	var out struct {
+		URI      string                `json:"uri"`
+		Outbound []relatedNeighborJSON `json:"outbound"`
+		Inbound  []relatedNeighborJSON `json:"inbound"`
+	}
+	callTool(t, cs, "mnemos.related", map[string]any{"uri": "a.md"}, &out)
+
+	require.Equal(t, "a.md", out.URI)
+	require.True(t, neighborSet(out.Outbound)["b.md"], "a.md links out to b.md")
+	require.True(t, neighborSet(out.Inbound)["b.md"], "b.md links back to a.md")
+
+	// Direction filter: inbound only.
+	var inbound struct {
+		Outbound []relatedNeighborJSON `json:"outbound"`
+		Inbound  []relatedNeighborJSON `json:"inbound"`
+	}
+	callTool(t, cs, "mnemos.related", map[string]any{"uri": "a.md", "direction": "inbound"}, &inbound)
+	require.Empty(t, inbound.Outbound)
+	require.True(t, neighborSet(inbound.Inbound)["b.md"])
+}
+
+func TestReadToolFollowLinks(t *testing.T) {
+	cs := connect(t, linkedCorpus(t))
+
+	var plain struct {
+		URI       string                `json:"uri"`
+		Neighbors []relatedNeighborJSON `json:"neighbors"`
+	}
+	callTool(t, cs, "mnemos.read", map[string]any{"uri": "a.md"}, &plain)
+	require.Empty(t, plain.Neighbors, "read without follow_links omits neighbors")
+
+	var linked struct {
+		URI       string                `json:"uri"`
+		Neighbors []relatedNeighborJSON `json:"neighbors"`
+	}
+	callTool(t, cs, "mnemos.read", map[string]any{"uri": "a.md", "follow_links": true}, &linked)
+	require.True(t, neighborSet(linked.Neighbors)["b.md"], "follow_links attaches b.md")
+}
+
+type contextBlockNeighborsJSON struct {
+	Source    string                `json:"source"`
+	Neighbors []relatedNeighborJSON `json:"neighbors"`
+}
+
+type contextNeighborsJSON struct {
+	Context []contextBlockNeighborsJSON `json:"context"`
+}
+
+func TestContextToolFollowLinks(t *testing.T) {
+	cs := connect(t, linkedCorpus(t))
+
+	var out contextNeighborsJSON
+	callTool(t, cs, "mnemos.context", map[string]any{"query": "See", "follow_links": true}, &out)
+
+	require.NotEmpty(t, out.Context)
+	require.Contains(t, out.Context[0].Source, "a.md:")
+	require.True(t, neighborSet(out.Context[0].Neighbors)["b.md"])
+}

--- a/internal/mcp/tools_remember.go
+++ b/internal/mcp/tools_remember.go
@@ -46,12 +46,12 @@ func (s *Server) registerRemember() {
 	}, s.handleRemember)
 }
 
-func (s *Server) handleRemember(ctx context.Context, _ *mcpsdk.CallToolRequest, in rememberInput) (*mcpsdk.CallToolResult, rememberOutput, error) {
+func (s *Server) handleRemember(ctx context.Context, _ *mcpsdk.CallToolRequest, in rememberInput) (*mcpsdk.CallToolResult, any, error) {
 	// Defensive re-check: the tool is only registered when allow_write is true,
 	// and the service re-checks too, but the handler refuses regardless so the
 	// gate cannot be bypassed.
 	if !s.cfg.MCP.AllowWrite {
-		return nil, rememberOutput{}, errors.New("write disabled: set [mcp].allow_write=true")
+		return nil, nil, errors.New("write disabled: set [mcp].allow_write=true")
 	}
 
 	res, err := s.svc.Remember(ctx, memory.RememberInput{
@@ -62,14 +62,14 @@ func (s *Server) handleRemember(ctx context.Context, _ *mcpsdk.CallToolRequest, 
 		Path:       in.Path,
 	})
 	if err != nil {
-		return nil, rememberOutput{}, err
+		return nil, nil, err
 	}
 
-	return nil, rememberOutput{
+	return s.result(rememberOutput{
 		URI:        res.URI,
 		DocumentID: res.DocumentID,
 		Chunks:     res.Chunks,
 		Type:       res.Type,
 		Deferred:   res.Deferred,
-	}, nil
+	})
 }

--- a/internal/mcp/tools_search.go
+++ b/internal/mcp/tools_search.go
@@ -48,7 +48,7 @@ func (s *Server) registerSearch() {
 	}, s.handleSearch)
 }
 
-func (s *Server) handleSearch(ctx context.Context, _ *mcpsdk.CallToolRequest, in searchInput) (*mcpsdk.CallToolResult, searchOutput, error) {
+func (s *Server) handleSearch(ctx context.Context, _ *mcpsdk.CallToolRequest, in searchInput) (*mcpsdk.CallToolResult, any, error) {
 	results, err := s.svc.Search(ctx, s.retriever, search.Query{
 		Text:          in.Query,
 		Collection:    in.Collection,
@@ -58,7 +58,7 @@ func (s *Server) handleSearch(ctx context.Context, _ *mcpsdk.CallToolRequest, in
 		Limit:         in.Limit,
 	})
 	if err != nil {
-		return nil, searchOutput{}, err
+		return nil, nil, err
 	}
 
 	out := searchOutput{Results: make([]searchResult, 0, len(results))}
@@ -66,7 +66,7 @@ func (s *Server) handleSearch(ctx context.Context, _ *mcpsdk.CallToolRequest, in
 		out.Results = append(out.Results, toSearchResult(r))
 	}
 
-	return nil, out, nil
+	return s.result(out)
 }
 
 // toSearchResult maps an internal Result to the MCP output shape, deriving a

--- a/internal/mcp/tools_search.go
+++ b/internal/mcp/tools_search.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"math"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -61,6 +62,10 @@ func (s *Server) handleSearch(ctx context.Context, _ *mcpsdk.CallToolRequest, in
 		return nil, nil, err
 	}
 
+	// Trim the low-relevance tail so the agent is not fed filler hits just to
+	// reach the limit.
+	results = search.RelevanceCliff(results)
+
 	out := searchOutput{Results: make([]searchResult, 0, len(results))}
 	for _, r := range results {
 		out.Results = append(out.Results, toSearchResult(r))
@@ -69,9 +74,9 @@ func (s *Server) handleSearch(ctx context.Context, _ *mcpsdk.CallToolRequest, in
 	return s.result(out)
 }
 
-// toSearchResult maps an internal Result to the MCP output shape, deriving a
-// Title from the last heading-path segment (the document title is not carried on
-// Result, so the heading is the best available label).
+// toSearchResult maps an internal Result to the MCP output shape, preferring the
+// document's stored title and rounding the score to one decimal at the JSON
+// boundary (bm25 + boost carries meaningless extra precision).
 func toSearchResult(r model.Result) searchResult {
 	return searchResult{
 		Title:       resultTitle(r),
@@ -80,16 +85,26 @@ func toSearchResult(r model.Result) searchResult {
 		StartLine:   r.StartLine,
 		EndLine:     r.EndLine,
 		Snippet:     r.Snippet,
-		Score:       r.Score,
+		Score:       roundScore(r.Score),
 	}
 }
 
-// resultTitle returns the last segment of the heading path, falling back to the
-// uri when the chunk has no heading.
+// resultTitle returns the document's stored title, falling back to the last
+// heading-path segment, then the uri, so a hit always carries a human label.
 func resultTitle(r model.Result) string {
+	if r.Title != "" {
+		return r.Title
+	}
 	if h := model.LastHeading(r.HeadingPath); h != "" {
 		return h
 	}
 
 	return r.URI
+}
+
+// roundScore rounds a relevance score to one decimal place. Search ranks on
+// bm25 plus a small heading boost; the trailing precision is noise that only
+// inflates the response, so it is trimmed at the wire boundary.
+func roundScore(score float64) float64 {
+	return math.Round(score*10) / 10
 }

--- a/internal/mcp/tools_search.go
+++ b/internal/mcp/tools_search.go
@@ -29,6 +29,7 @@ type searchInput struct {
 type searchResult struct {
 	Title       string  `json:"title"`
 	URI         string  `json:"uri"`
+	Collection  string  `json:"collection"`
 	HeadingPath string  `json:"heading_path"`
 	StartLine   int     `json:"start_line"`
 	EndLine     int     `json:"end_line"`
@@ -81,6 +82,7 @@ func toSearchResult(r model.Result) searchResult {
 	return searchResult{
 		Title:       resultTitle(r),
 		URI:         r.URI,
+		Collection:  r.Collection,
 		HeadingPath: r.HeadingPath,
 		StartLine:   r.StartLine,
 		EndLine:     r.EndLine,

--- a/internal/memory/inject_test.go
+++ b/internal/memory/inject_test.go
@@ -1,0 +1,82 @@
+package memory_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/memory"
+	"github.com/arhuman/mnemos/internal/search"
+)
+
+// neighborURIs collapses a neighbor slice to a uri set for assertions.
+func neighborURIs(ns []memory.RelatedNeighbor) map[string]bool {
+	out := make(map[string]bool, len(ns))
+	for _, n := range ns {
+		out[n.URI] = true
+	}
+
+	return out
+}
+
+func TestReadFollowLinksOptIn(t *testing.T) {
+	f := newFixture(t, false, false)
+	seedLinkGraph(t, f) // docs/a.md -> {b.md, ghost.md}; docs/b.md -> a.md
+	ctx := context.Background()
+
+	// Default read attaches nothing.
+	plain, err := f.svc.ReadOneOpts(ctx, "docs/a.md", "", memory.ReadOptions{})
+	require.NoError(t, err)
+	require.Empty(t, plain.Neighbors)
+
+	// follow_links attaches outbound (resolved b.md + dangling ghost.md) and
+	// inbound (b.md backlink).
+	res, err := f.svc.ReadOneOpts(ctx, "docs/a.md", "", memory.ReadOptions{FollowLinks: true})
+	require.NoError(t, err)
+	uris := neighborURIs(res.Neighbors)
+	require.True(t, uris["docs/b.md"], "outbound + inbound b.md")
+	require.True(t, uris["docs/ghost.md"], "dangling outbound ghost.md")
+}
+
+func TestReadFollowLinksDirectionAndLimit(t *testing.T) {
+	f := newFixture(t, false, false)
+	seedLinkGraph(t, f)
+	ctx := context.Background()
+
+	// Inbound only: docs/a.md's backlink is docs/b.md; ghost.md (outbound) absent.
+	in, err := f.svc.ReadOneOpts(ctx, "docs/a.md", "", memory.ReadOptions{
+		FollowLinks:   true,
+		LinkDirection: memory.DirectionInbound,
+	})
+	require.NoError(t, err)
+	uris := neighborURIs(in.Neighbors)
+	require.True(t, uris["docs/b.md"])
+	require.False(t, uris["docs/ghost.md"])
+	for _, n := range in.Neighbors {
+		require.Equal(t, "inbound", n.Direction)
+	}
+}
+
+func TestContextFollowLinksOptIn(t *testing.T) {
+	f := newFixture(t, false, false)
+	seedLinkGraph(t, f)
+	ctx := context.Background()
+
+	// "Ghost" appears only in docs/a.md, so it is the top block.
+	q := search.Query{Text: "Ghost"}
+
+	plain, err := f.svc.ContextWithOptions(ctx, f.retriever, q, memory.ContextOptions{GroupByDocument: true})
+	require.NoError(t, err)
+	require.NotEmpty(t, plain)
+	require.Empty(t, plain[0].Neighbors)
+
+	linked, err := f.svc.ContextWithOptions(ctx, f.retriever, q, memory.ContextOptions{
+		GroupByDocument: true,
+		FollowLinks:     true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, linked)
+	require.Contains(t, linked[0].Source, "docs/a.md:")
+	require.True(t, neighborURIs(linked[0].Neighbors)["docs/b.md"], "a.md's neighbors should include b.md")
+}

--- a/internal/memory/list.go
+++ b/internal/memory/list.go
@@ -26,9 +26,34 @@ func (s *Service) List(ctx context.Context, opts browse.Options) ([]browse.Entry
 	if err != nil {
 		return nil, fmt.Errorf("memory: list: %w", err)
 	}
-	if entries == nil {
-		entries = []browse.Entry{}
+
+	return hideCollections(entries, s.cfg.HiddenCollections()), nil
+}
+
+// hideCollections drops entries whose collection is in the deny list — the
+// server-side visibility boundary applied to list/ls, matching the query-layer
+// exclusion the search path applies. An un-indexed file has no collection
+// attribution, so it is never dropped here (there is nothing hidden to leak). A
+// nil result is normalized to an empty slice.
+func hideCollections(entries []browse.Entry, deny []string) []browse.Entry {
+	if len(deny) == 0 {
+		if entries == nil {
+			return []browse.Entry{}
+		}
+
+		return entries
+	}
+	hidden := make(map[string]bool, len(deny))
+	for _, c := range deny {
+		hidden[c] = true
+	}
+	out := make([]browse.Entry, 0, len(entries))
+	for _, e := range entries {
+		if e.Collection != "" && hidden[e.Collection] {
+			continue
+		}
+		out = append(out, e)
 	}
 
-	return entries, nil
+	return out
 }

--- a/internal/memory/read.go
+++ b/internal/memory/read.go
@@ -31,6 +31,10 @@ type ReadResult struct {
 	Content    string
 	Truncated  bool
 	Citation   *Citation
+	// Neighbors is the document's 1-hop link neighborhood, populated only when
+	// ReadOptions.FollowLinks is set. Empty when the document has no visible
+	// neighbors.
+	Neighbors []RelatedNeighbor
 }
 
 // ReadOptions narrows and bounds a read. Section and Lines scope a document read
@@ -47,6 +51,13 @@ type ReadOptions struct {
 	Lines     string
 	MaxChars  int
 	MaxTokens int
+	// FollowLinks, when set, attaches the read document's 1-hop link neighborhood
+	// to the result (best-effort: it never fails an otherwise-successful read).
+	FollowLinks bool
+	// LinkLimit caps neighbors per direction when FollowLinks is set (0 = default).
+	LinkLimit int
+	// LinkDirection selects which edges to follow (empty = both).
+	LinkDirection Direction
 }
 
 // hiddenCollection reports whether collection is on the server-side visibility
@@ -228,6 +239,10 @@ func (s *Service) ReadOneOpts(ctx context.Context, uri, chunkID string, opts Rea
 	}
 
 	res.Content, res.Truncated = truncateContent(res.Content, charBudget(opts.MaxChars, opts.MaxTokens))
+
+	if opts.FollowLinks {
+		res.Neighbors = s.neighborsFor(ctx, res.URI, opts.LinkDirection, opts.LinkLimit)
+	}
 
 	return res, nil
 }

--- a/internal/memory/read.go
+++ b/internal/memory/read.go
@@ -21,13 +21,31 @@ type Citation struct {
 
 // ReadResult is the outcome of reading a document or a single chunk. Content is
 // the chunk text or the reconstructed document body; the metadata fields locate
-// it. Citation is set only for a chunk read.
+// it. Citation is set only for a chunk read. Truncated reports that a size budget
+// clipped Content, signalling the caller to read deeper if it needs the rest.
 type ReadResult struct {
 	URI        string
 	Collection string
 	Title      string
 	Content    string
+	Truncated  bool
 	Citation   *Citation
+}
+
+// ReadOptions narrows and bounds a read. Section and Lines scope a document read
+// to a subset of its chunks (both empty reads the whole document); they are
+// ignored for a single-chunk read, which is already a fragment. MaxChars and
+// MaxTokens cap the returned Content (see charBudget); the zero value of every
+// field reproduces the unbounded whole-document/whole-chunk read.
+type ReadOptions struct {
+	// Section keeps only chunks whose heading path contains this text
+	// (case-insensitive), e.g. "Definition of done".
+	Section string
+	// Lines keeps only chunks overlapping this 1-based inclusive source-line span,
+	// written "start-end" or a bare "start".
+	Lines     string
+	MaxChars  int
+	MaxTokens int
 }
 
 // ReadChunk returns a single chunk's content and its citation. An unknown
@@ -65,16 +83,31 @@ func (s *Service) ReadChunk(ctx context.Context, chunkID string) (ReadResult, er
 	}, nil
 }
 
-// ReadDocument reconstructs a document from its stored chunks ordered by
-// ordinal, de-duplicating the overlapping line ranges the windowed chunker
-// emits. An unknown uri is a not-found error.
+// ReadDocument reconstructs a whole document from its stored chunks. It is the
+// unbounded, unscoped read; ReadDocumentOpts adds section/line scoping.
 func (s *Service) ReadDocument(ctx context.Context, uri string) (ReadResult, error) {
+	return s.ReadDocumentOpts(ctx, uri, ReadOptions{})
+}
+
+// ReadDocumentOpts reconstructs a document from its stored chunks ordered by
+// ordinal, de-duplicating the overlapping line ranges the windowed chunker emits.
+// When opts.Section or opts.Lines is set it first narrows to the matching chunks,
+// so a caller can pull one heading or line span instead of the whole document. An
+// unknown uri is a not-found error; a scope that matches no chunk is an error too,
+// so an empty read is never silently returned. Size budgets are applied by the
+// ReadOneOpts caller, uniformly with chunk reads.
+func (s *Service) ReadDocumentOpts(ctx context.Context, uri string, opts ReadOptions) (ReadResult, error) {
 	chunks, err := storage.GetChunksByDocURI(ctx, s.db, uri)
 	if err != nil {
 		return ReadResult{}, fmt.Errorf("memory: read document: %w", err)
 	}
 	if len(chunks) == 0 {
 		return ReadResult{}, fmt.Errorf("unknown uri %q", uri)
+	}
+
+	chunks, err = scopeChunks(chunks, opts, uri)
+	if err != nil {
+		return ReadResult{}, err
 	}
 
 	doc, err := storage.GetDocumentByURI(ctx, s.db, uri)
@@ -95,6 +128,40 @@ func (s *Service) ReadDocument(ctx context.Context, uri string) (ReadResult, err
 	}, nil
 }
 
+// scopeChunks narrows chunks to those matching opts.Section and/or opts.Lines,
+// preserving order. Both empty returns chunks unchanged. A scope that matches no
+// chunk is an error (naming uri) rather than an empty document.
+func scopeChunks(chunks []model.Chunk, opts ReadOptions, uri string) ([]model.Chunk, error) {
+	if opts.Section == "" && opts.Lines == "" {
+		return chunks, nil
+	}
+	var lr lineRange
+	if opts.Lines != "" {
+		var err error
+		if lr, err = parseLineRange(opts.Lines); err != nil {
+			return nil, fmt.Errorf("memory: read %q: %w", uri, err)
+		}
+	}
+	section := strings.ToLower(opts.Section)
+
+	out := make([]model.Chunk, 0, len(chunks))
+	for _, c := range chunks {
+		if section != "" && !strings.Contains(strings.ToLower(c.HeadingPath), section) {
+			continue
+		}
+		// Skip chunks whose [StartLine, EndLine] does not intersect the request.
+		if opts.Lines != "" && (c.StartLine > lr.End || c.EndLine < lr.Start) {
+			continue
+		}
+		out = append(out, c)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no chunk in %q matches the requested section/lines", uri)
+	}
+
+	return out, nil
+}
+
 // ErrAmbiguousRead and ErrEmptyRead document the two invalid read selectors a
 // surface may pass; surfaces validate their own input shape, but ReadOne lets a
 // surface delegate the choice too.
@@ -103,22 +170,42 @@ var (
 	ErrEmptyRead     = errors.New("provide exactly one of uri or chunk_id")
 )
 
-// ReadOne dispatches to ReadDocument or ReadChunk based on which of uri/chunkID
-// is set, rejecting the both-set and neither-set cases. It is the single entry
-// the MCP read tool delegates to.
+// ReadOne dispatches an unbounded read of a document or chunk. It is
+// ReadOneOpts with the zero ReadOptions.
 func (s *Service) ReadOne(ctx context.Context, uri, chunkID string) (ReadResult, error) {
+	return s.ReadOneOpts(ctx, uri, chunkID, ReadOptions{})
+}
+
+// ReadOneOpts dispatches to ReadDocumentOpts or ReadChunk based on which of
+// uri/chunkID is set, rejecting the both-set and neither-set cases, then applies
+// the size budget to the returned content uniformly (section/line scoping applies
+// to document reads only; a chunk is already a fragment). It is the single entry
+// the MCP read tool delegates to.
+func (s *Service) ReadOneOpts(ctx context.Context, uri, chunkID string, opts ReadOptions) (ReadResult, error) {
 	hasURI := uri != ""
 	hasChunk := chunkID != ""
+
+	var (
+		res ReadResult
+		err error
+	)
 	switch {
 	case hasURI && hasChunk:
 		return ReadResult{}, ErrAmbiguousRead
 	case !hasURI && !hasChunk:
 		return ReadResult{}, ErrEmptyRead
 	case hasChunk:
-		return s.ReadChunk(ctx, chunkID)
+		res, err = s.ReadChunk(ctx, chunkID)
 	default:
-		return s.ReadDocument(ctx, uri)
+		res, err = s.ReadDocumentOpts(ctx, uri, opts)
 	}
+	if err != nil {
+		return ReadResult{}, err
+	}
+
+	res.Content, res.Truncated = truncateContent(res.Content, charBudget(opts.MaxChars, opts.MaxTokens))
+
+	return res, nil
 }
 
 // reconstruct stitches ordinal-ordered chunks back into the source body while

--- a/internal/memory/read.go
+++ b/internal/memory/read.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/arhuman/mnemos/internal/model"
@@ -48,8 +49,22 @@ type ReadOptions struct {
 	MaxTokens int
 }
 
+// hiddenCollection reports whether collection is on the server-side visibility
+// deny list ([security].visibility.deny). The read verbs use it to treat a hidden
+// document exactly like an absent one: a hidden collection must never surface even
+// when a caller names a uri or chunk_id in it, and it must be indistinguishable
+// from a genuine not-found so read cannot be used as an existence oracle.
+func (s *Service) hiddenCollection(collection string) bool {
+	if collection == "" {
+		return false
+	}
+
+	return slices.Contains(s.cfg.HiddenCollections(), collection)
+}
+
 // ReadChunk returns a single chunk's content and its citation. An unknown
-// chunk_id is a not-found error, not a crash.
+// chunk_id is a not-found error, not a crash. A chunk in a hidden collection
+// returns the same not-found error as a missing one (see hiddenCollection).
 func (s *Service) ReadChunk(ctx context.Context, chunkID string) (ReadResult, error) {
 	c, err := storage.GetChunkByID(ctx, s.db, chunkID)
 	if err != nil {
@@ -62,6 +77,9 @@ func (s *Service) ReadChunk(ctx context.Context, chunkID string) (ReadResult, er
 	doc, err := storage.GetDocumentByID(ctx, s.db, c.DocumentID)
 	if err != nil {
 		return ReadResult{}, fmt.Errorf("memory: read chunk document: %w", err)
+	}
+	if doc != nil && s.hiddenCollection(doc.Collection) {
+		return ReadResult{}, fmt.Errorf("unknown chunk_id %q", chunkID)
 	}
 
 	uri, collection, title := "", "", ""
@@ -105,14 +123,20 @@ func (s *Service) ReadDocumentOpts(ctx context.Context, uri string, opts ReadOpt
 		return ReadResult{}, fmt.Errorf("unknown uri %q", uri)
 	}
 
-	chunks, err = scopeChunks(chunks, opts, uri)
-	if err != nil {
-		return ReadResult{}, err
-	}
-
+	// Fetch the document before scoping so a hidden collection returns the same
+	// not-found error as a missing uri, ahead of (and indistinguishable from) any
+	// section/line scope-mismatch error.
 	doc, err := storage.GetDocumentByURI(ctx, s.db, uri)
 	if err != nil {
 		return ReadResult{}, fmt.Errorf("memory: read document metadata: %w", err)
+	}
+	if doc != nil && s.hiddenCollection(doc.Collection) {
+		return ReadResult{}, fmt.Errorf("unknown uri %q", uri)
+	}
+
+	chunks, err = scopeChunks(chunks, opts, uri)
+	if err != nil {
+		return ReadResult{}, err
 	}
 
 	collection, title := "", ""

--- a/internal/memory/related.go
+++ b/internal/memory/related.go
@@ -1,0 +1,116 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+// Direction selects which link edges Related traverses.
+type Direction string
+
+const (
+	// DirectionOutbound follows links the document contains.
+	DirectionOutbound Direction = "outbound"
+	// DirectionInbound follows backlinks that point at the document.
+	DirectionInbound Direction = "inbound"
+	// DirectionBoth follows both; it is also the zero-value default.
+	DirectionBoth Direction = "both"
+)
+
+// defaultRelatedLimit caps neighbors per direction when the caller leaves limit
+// unset, so a hub document does not return an unbounded list.
+const defaultRelatedLimit = 50
+
+// RelatedNeighbor is one 1-hop link-graph neighbor of a document. Resolved is
+// false for a dangling outbound link (the target uri is not an ingested
+// document), in which case Title and Collection are empty. Inbound neighbors are
+// always resolved.
+type RelatedNeighbor struct {
+	URI        string `json:"uri"`
+	Title      string `json:"title,omitempty"`
+	Collection string `json:"collection,omitempty"`
+	Direction  string `json:"direction"`
+	Resolved   bool   `json:"resolved"`
+}
+
+// RelatedResult is the link-graph neighborhood of a document: the outbound links
+// it contains and the inbound backlinks that point at it, one hop out. A
+// direction not requested is nil.
+type RelatedResult struct {
+	URI      string            `json:"uri"`
+	Outbound []RelatedNeighbor `json:"outbound"`
+	Inbound  []RelatedNeighbor `json:"inbound"`
+}
+
+// Related returns the 1-hop link-graph neighbors of the document at uri, honoring
+// the server-side visibility boundary ([security].visibility.deny): a neighbor in
+// a hidden collection is dropped, and an unknown or hidden uri returns the same
+// not-found error as a missing document (mirroring the read verbs). dir selects
+// outbound, inbound, or both (the zero value "" is treated as both); limit caps
+// each direction (<= 0 uses the default). Edges are document-granularity, so
+// results locate documents; the agent reads or searches within one to get cited
+// chunks.
+func (s *Service) Related(ctx context.Context, uri string, dir Direction, limit int) (RelatedResult, error) {
+	if uri == "" {
+		return RelatedResult{}, errors.New("provide a uri")
+	}
+
+	// Existence + visibility gate, identical to ReadDocument, so Related cannot be
+	// used as an oracle for hidden documents.
+	doc, err := storage.GetDocumentByURI(ctx, s.db, uri)
+	if err != nil {
+		return RelatedResult{}, fmt.Errorf("memory: related document: %w", err)
+	}
+	if doc == nil || s.hiddenCollection(doc.Collection) {
+		return RelatedResult{}, fmt.Errorf("unknown uri %q", uri)
+	}
+
+	if limit <= 0 {
+		limit = defaultRelatedLimit
+	}
+
+	res := RelatedResult{URI: uri}
+	if dir == DirectionOutbound || dir == DirectionBoth || dir == "" {
+		ns, err := storage.OutboundNeighbors(ctx, s.db, uri)
+		if err != nil {
+			return RelatedResult{}, fmt.Errorf("memory: related outbound: %w", err)
+		}
+		res.Outbound = s.visibleNeighbors(ns, limit)
+	}
+	if dir == DirectionInbound || dir == DirectionBoth || dir == "" {
+		ns, err := storage.InboundNeighbors(ctx, s.db, uri)
+		if err != nil {
+			return RelatedResult{}, fmt.Errorf("memory: related inbound: %w", err)
+		}
+		res.Inbound = s.visibleNeighbors(ns, limit)
+	}
+
+	return res, nil
+}
+
+// visibleNeighbors drops neighbors in hidden collections and caps the result to
+// limit, preserving the storage-layer ordering. A dangling outbound neighbor has
+// an empty collection, which is never hidden, so it is kept.
+func (s *Service) visibleNeighbors(ns []storage.Neighbor, limit int) []RelatedNeighbor {
+	out := make([]RelatedNeighbor, 0, len(ns))
+	for _, n := range ns {
+		if s.hiddenCollection(n.Collection) {
+			continue
+		}
+		out = append(out, RelatedNeighbor{
+			URI:        n.URI,
+			Title:      n.Title,
+			Collection: n.Collection,
+			Direction:  n.Direction,
+			Resolved:   n.Resolved,
+		})
+		if len(out) >= limit {
+			break
+		}
+	}
+
+	return out
+}

--- a/internal/memory/related.go
+++ b/internal/memory/related.go
@@ -91,6 +91,29 @@ func (s *Service) Related(ctx context.Context, uri string, dir Direction, limit 
 	return res, nil
 }
 
+// neighborsFor returns the flattened 1-hop neighbors (outbound then inbound) of
+// uri for link injection, honoring visibility and the per-direction cap. It is
+// the shared path behind read/context follow_links and is best-effort: a uri that
+// resolves to no visible document, or any lookup error, yields nil rather than
+// failing the surrounding read/context call.
+func (s *Service) neighborsFor(ctx context.Context, uri string, dir Direction, limit int) []RelatedNeighbor {
+	if uri == "" {
+		return nil
+	}
+	res, err := s.Related(ctx, uri, dir, limit)
+	if err != nil {
+		return nil
+	}
+	out := make([]RelatedNeighbor, 0, len(res.Outbound)+len(res.Inbound))
+	out = append(out, res.Outbound...)
+	out = append(out, res.Inbound...)
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
 // visibleNeighbors drops neighbors in hidden collections and caps the result to
 // limit, preserving the storage-layer ordering. A dangling outbound neighbor has
 // an empty collection, which is never hidden, so it is kept.

--- a/internal/memory/related_bench_test.go
+++ b/internal/memory/related_bench_test.go
@@ -1,0 +1,102 @@
+package memory_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/chunk"
+	"github.com/arhuman/mnemos/internal/config"
+	"github.com/arhuman/mnemos/internal/ingest"
+	"github.com/arhuman/mnemos/internal/memory"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+// benchInjectionService seeds a hub document with `fan` outbound links and `fan`
+// inbound backlinks, then returns a service over it. It lets the benchmarks
+// compare a plain read against a read plus the neighbor lookup that read/context
+// injection would add.
+func benchInjectionService(b *testing.B, fan int) *memory.Service {
+	b.Helper()
+	ctx := context.Background()
+	dir := b.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	db, err := storage.Open(ctx, filepath.Join(dir, "bench.db"))
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = db.Close() })
+	require.NoError(b, storage.Migrate(db))
+
+	chunking := chunk.Config{TargetTokens: 700, OverlapTokens: 80}
+	writeAndIngest := func(rel, content string) {
+		p := filepath.Join(dir, rel)
+		require.NoError(b, os.MkdirAll(filepath.Dir(p), 0o750))
+		require.NoError(b, os.WriteFile(p, []byte(content), 0o600))
+		_, _, ferr := ingest.File(ctx, db, logger, p, filepath.ToSlash(rel), "demo", chunking)
+		require.NoError(b, ferr)
+	}
+
+	// A hub with real body text (so the read has work) plus `fan` outbound links.
+	var hub strings.Builder
+	_, _ = hub.WriteString("# Hub\n\nThis hub document links out to many detail docs.\n\n")
+	for i := range fan {
+		_, _ = fmt.Fprintf(&hub, "- see [detail %d](t%d.md)\n", i, i)
+	}
+	writeAndIngest("hub.md", hub.String())
+
+	// `fan` detail docs, each linking back to the hub (inbound edges).
+	for i := range fan {
+		writeAndIngest(fmt.Sprintf("t%d.md", i), fmt.Sprintf("# Detail %d\n\nBack to [hub](hub.md).\n", i))
+	}
+
+	cfg, err := config.Load("", func(string) bool { return false })
+	require.NoError(b, err)
+
+	return memory.New(db, cfg, dir, nil, logger)
+}
+
+func BenchmarkReadDocument(b *testing.B) {
+	svc := benchInjectionService(b, 25)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := svc.ReadDocument(ctx, "hub.md"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkReadDocumentThenRelated measures a read plus the neighbor lookup that
+// automatic injection would add; the delta versus BenchmarkReadDocument is the
+// per-call cost of injection.
+func BenchmarkReadDocumentThenRelated(b *testing.B) {
+	svc := benchInjectionService(b, 25)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := svc.ReadDocument(ctx, "hub.md"); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := svc.Related(ctx, "hub.md", memory.DirectionBoth, 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRelated(b *testing.B) {
+	svc := benchInjectionService(b, 25)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := svc.Related(ctx, "hub.md", memory.DirectionBoth, 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/memory/related_test.go
+++ b/internal/memory/related_test.go
@@ -1,0 +1,103 @@
+package memory_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/config"
+	"github.com/arhuman/mnemos/internal/memory"
+	"github.com/arhuman/mnemos/internal/testutil"
+)
+
+// seedLinkGraph seeds a small vault under docs/: a.md links to b.md and a
+// dangling ghost.md; b.md links back to a.md. Relative link targets resolve
+// against the source file's directory, so the links land under docs/.
+func seedLinkGraph(t *testing.T, f fixture) {
+	t.Helper()
+	f.seed(t, "docs/a.md", "# A\n\nSee [B](b.md) and [Ghost](ghost.md).\n", "default")
+	f.seed(t, "docs/b.md", "# B\n\nBack to [A](a.md).\n", "default")
+}
+
+func TestRelatedBothDirections(t *testing.T) {
+	f := newFixture(t, false, false)
+	seedLinkGraph(t, f)
+
+	res, err := f.svc.Related(context.Background(), "docs/a.md", memory.DirectionBoth, 0)
+	require.NoError(t, err)
+	require.Equal(t, "docs/a.md", res.URI)
+
+	// Outbound: docs/b.md (resolved) and docs/ghost.md (dangling), ordered by uri.
+	require.Len(t, res.Outbound, 2)
+	require.Equal(t, "docs/b.md", res.Outbound[0].URI)
+	require.True(t, res.Outbound[0].Resolved)
+	require.Equal(t, "docs/ghost.md", res.Outbound[1].URI)
+	require.False(t, res.Outbound[1].Resolved)
+
+	// Inbound: docs/b.md links back to docs/a.md.
+	require.Len(t, res.Inbound, 1)
+	require.Equal(t, "docs/b.md", res.Inbound[0].URI)
+	require.True(t, res.Inbound[0].Resolved)
+}
+
+func TestRelatedDirectionFilter(t *testing.T) {
+	f := newFixture(t, false, false)
+	seedLinkGraph(t, f)
+	ctx := context.Background()
+
+	out, err := f.svc.Related(ctx, "docs/a.md", memory.DirectionOutbound, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Outbound)
+	require.Nil(t, out.Inbound)
+
+	in, err := f.svc.Related(ctx, "docs/a.md", memory.DirectionInbound, 0)
+	require.NoError(t, err)
+	require.Nil(t, in.Outbound)
+	require.NotEmpty(t, in.Inbound)
+}
+
+func TestRelatedUnknownURIIsNotFound(t *testing.T) {
+	f := newFixture(t, false, false)
+	seedLinkGraph(t, f)
+
+	_, err := f.svc.Related(context.Background(), "docs/missing.md", memory.DirectionBoth, 0)
+	require.Error(t, err)
+
+	_, err = f.svc.Related(context.Background(), "", memory.DirectionBoth, 0)
+	require.Error(t, err)
+}
+
+func TestRelatedHidesDeniedCollections(t *testing.T) {
+	f := newFixture(t, false, false)
+	seedLinkGraph(t, f)
+	// A secret doc that links to docs/a.md; its backlink must not surface once the
+	// collection is on the visibility deny list.
+	f.seed(t, "docs/secret.md", "# Secret\n\nRefers to [A](a.md).\n", "secret")
+
+	// Without a deny list, the secret backlink is visible.
+	visible, err := f.svc.Related(context.Background(), "docs/a.md", memory.DirectionInbound, 0)
+	require.NoError(t, err)
+	require.Len(t, visible.Inbound, 2)
+
+	// With "secret" denied, only docs/b.md remains.
+	cfgDeny, err := config.Load("", func(string) bool { return false })
+	require.NoError(t, err)
+	cfgDeny.Security.Visibility.Deny = []string{"secret"}
+	denySvc := memory.New(f.db, cfgDeny, f.treeRoot, nil, testutil.DiscardLogger())
+
+	hidden, err := denySvc.Related(context.Background(), "docs/a.md", memory.DirectionInbound, 0)
+	require.NoError(t, err)
+	require.Len(t, hidden.Inbound, 1)
+	require.Equal(t, "docs/b.md", hidden.Inbound[0].URI)
+}
+
+func TestRelatedLimitPerDirection(t *testing.T) {
+	f := newFixture(t, false, false)
+	// hub.md links to three targets; limit=2 caps outbound at two.
+	f.seed(t, "docs/hub.md", "# Hub\n\n[1](one.md) [2](two.md) [3](three.md)\n", "default")
+
+	res, err := f.svc.Related(context.Background(), "docs/hub.md", memory.DirectionOutbound, 2)
+	require.NoError(t, err)
+	require.Len(t, res.Outbound, 2)
+}

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -90,21 +90,66 @@ func (s *Service) Search(ctx context.Context, r search.Retriever, q search.Query
 }
 
 // ContextBlock is one retrieved passage ready to inject into an LLM prompt:
-// Source cites it as "uri:start-end" and Content is the full chunk text.
+// Source cites it as "uri:start-end", Content is the chunk text, and Title /
+// ModifiedAt label its owning document (empty when the document stored neither).
+// Truncated reports that a size budget clipped Content.
 type ContextBlock struct {
-	Source  string
-	Content string
+	Source     string
+	Title      string
+	ModifiedAt string
+	Content    string
+	Truncated  bool
 }
 
-// Context runs q through r and batch-loads each hit's full chunk content,
-// returning LLM-ready blocks in rank order. The retriever only returns a
+// ContextOptions shape a Context call. The zero value reproduces the original
+// flat, unbounded behavior; the MCP context tool opts into grouping and the
+// relevance cliff by default (see tools_context.go). GroupByDocument collapses
+// hits to the best chunk per document, widening recall breadth for a fixed limit;
+// Cliff trims the low-relevance tail; MaxChars/MaxTokens cap each block's content.
+type ContextOptions struct {
+	GroupByDocument bool
+	Cliff           bool
+	MaxChars        int
+	MaxTokens       int
+}
+
+// groupCandidateFactor is how many chunks Context over-fetches per requested
+// document when grouping, so collapsing to the best chunk per document can still
+// fill the limit with distinct documents rather than a handful repeated across
+// their chunks.
+const groupCandidateFactor = 4
+
+// Context runs q through r with the default (flat, unbounded) shaping.
+func (s *Service) Context(ctx context.Context, r search.Retriever, q search.Query) ([]ContextBlock, error) {
+	return s.ContextWithOptions(ctx, r, q, ContextOptions{})
+}
+
+// ContextWithOptions runs q through r and batch-loads each hit's full chunk
+// content, returning LLM-ready blocks in rank order. The retriever only returns a
 // highlighted snippet, so context fetches the whole chunk in one query (avoiding
 // the per-result N+1). A chunk that vanished between search and fetch falls back
-// to its snippet so the block still carries something.
-func (s *Service) Context(ctx context.Context, r search.Retriever, q search.Query) ([]ContextBlock, error) {
+// to its snippet so the block still carries something. When opts.GroupByDocument
+// is set it over-fetches candidates, keeps the best chunk per document, and caps
+// to the requested number of documents; opts.Cliff then trims the low-relevance
+// tail, and the size budget clips each block.
+func (s *Service) ContextWithOptions(ctx context.Context, r search.Retriever, q search.Query, opts ContextOptions) ([]ContextBlock, error) {
+	docLimit := s.resolveLimit(q.Limit)
+	if opts.GroupByDocument {
+		// Over-fetch chunks so the best-per-document collapse can still reach
+		// docLimit distinct documents.
+		q.Limit = docLimit * groupCandidateFactor
+	}
+
 	results, err := s.Search(ctx, r, q)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.GroupByDocument {
+		results = bestPerDocument(results, docLimit)
+	}
+	if opts.Cliff {
+		results = search.RelevanceCliff(results)
 	}
 
 	ids := make([]string, len(results))
@@ -116,17 +161,43 @@ func (s *Service) Context(ctx context.Context, r search.Retriever, q search.Quer
 		return nil, fmt.Errorf("memory: context chunks: %w", err)
 	}
 
+	budget := charBudget(opts.MaxChars, opts.MaxTokens)
 	blocks := make([]ContextBlock, 0, len(results))
 	for _, res := range results {
 		content, ok := contents[res.ID]
 		if !ok {
 			content = res.Snippet
 		}
+		content, truncated := truncateContent(content, budget)
 		blocks = append(blocks, ContextBlock{
-			Source:  fmt.Sprintf("%s:%d-%d", res.URI, res.StartLine, res.EndLine),
-			Content: content,
+			Source:     fmt.Sprintf("%s:%d-%d", res.URI, res.StartLine, res.EndLine),
+			Title:      res.Title,
+			ModifiedAt: res.ModifiedAt,
+			Content:    content,
+			Truncated:  truncated,
 		})
 	}
 
 	return blocks, nil
+}
+
+// bestPerDocument collapses rank-ordered results to the first (best-scoring) hit
+// per document uri, preserving order, and caps the count to limit documents.
+// Because results are already sorted best-first, the first hit seen for a uri is
+// its best chunk.
+func bestPerDocument(results []model.Result, limit int) []model.Result {
+	seen := make(map[string]bool, len(results))
+	out := make([]model.Result, 0, limit)
+	for _, r := range results {
+		if seen[r.URI] {
+			continue
+		}
+		seen[r.URI] = true
+		out = append(out, r)
+		if len(out) >= limit {
+			break
+		}
+	}
+
+	return out
 }

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -102,6 +102,9 @@ type ContextBlock struct {
 	ModifiedAt string
 	Content    string
 	Truncated  bool
+	// Neighbors is the block document's 1-hop link neighborhood, populated only
+	// when ContextOptions.FollowLinks is set.
+	Neighbors []RelatedNeighbor
 }
 
 // ContextOptions shape a Context call. The zero value reproduces the original
@@ -114,6 +117,14 @@ type ContextOptions struct {
 	Cliff           bool
 	MaxChars        int
 	MaxTokens       int
+	// FollowLinks, when set, attaches each block document's 1-hop link
+	// neighborhood to the block (best-effort). Neighbors are computed once per
+	// document across the result set.
+	FollowLinks bool
+	// LinkLimit caps neighbors per direction when FollowLinks is set (0 = default).
+	LinkLimit int
+	// LinkDirection selects which edges to follow (empty = both).
+	LinkDirection Direction
 }
 
 // groupCandidateFactor is how many chunks Context over-fetches per requested
@@ -165,6 +176,12 @@ func (s *Service) ContextWithOptions(ctx context.Context, r search.Retriever, q 
 	}
 
 	budget := charBudget(opts.MaxChars, opts.MaxTokens)
+	// Neighbors are per-document, so compute them once per uri and reuse across a
+	// document's chunks (relevant in group_by=chunk mode).
+	var linkCache map[string][]RelatedNeighbor
+	if opts.FollowLinks {
+		linkCache = make(map[string][]RelatedNeighbor)
+	}
 	blocks := make([]ContextBlock, 0, len(results))
 	for _, res := range results {
 		content, ok := contents[res.ID]
@@ -172,14 +189,23 @@ func (s *Service) ContextWithOptions(ctx context.Context, r search.Retriever, q 
 			content = res.Snippet
 		}
 		content, truncated := truncateContent(content, budget)
-		blocks = append(blocks, ContextBlock{
+		block := ContextBlock{
 			Source:     fmt.Sprintf("%s:%d-%d", res.URI, res.StartLine, res.EndLine),
 			Title:      res.Title,
 			Collection: res.Collection,
 			ModifiedAt: res.ModifiedAt,
 			Content:    content,
 			Truncated:  truncated,
-		})
+		}
+		if opts.FollowLinks {
+			nb, seen := linkCache[res.URI]
+			if !seen {
+				nb = s.neighborsFor(ctx, res.URI, opts.LinkDirection, opts.LinkLimit)
+				linkCache[res.URI] = nb
+			}
+			block.Neighbors = nb
+		}
+		blocks = append(blocks, block)
 	}
 
 	return blocks, nil

--- a/internal/memory/service.go
+++ b/internal/memory/service.go
@@ -77,10 +77,12 @@ func (s *Service) resolveLimit(limit int) int {
 }
 
 // Search runs q through r, applying the configured default limit when q.Limit is
-// unset. r is the retriever the surface chose (lexical FTS, or hybrid
-// lexical+vector); the service does not pick one.
+// unset and the server-side visibility boundary ([security].visibility.deny) so a
+// hidden collection can never surface. r is the retriever the surface chose
+// (lexical FTS, or hybrid lexical+vector); the service does not pick one.
 func (s *Service) Search(ctx context.Context, r search.Retriever, q search.Query) ([]model.Result, error) {
 	q.Limit = s.resolveLimit(q.Limit)
+	q.ExcludeCollections = s.cfg.HiddenCollections()
 	results, err := r.Search(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("memory: search: %w", err)
@@ -96,6 +98,7 @@ func (s *Service) Search(ctx context.Context, r search.Retriever, q search.Query
 type ContextBlock struct {
 	Source     string
 	Title      string
+	Collection string
 	ModifiedAt string
 	Content    string
 	Truncated  bool
@@ -172,6 +175,7 @@ func (s *Service) ContextWithOptions(ctx context.Context, r search.Retriever, q 
 		blocks = append(blocks, ContextBlock{
 			Source:     fmt.Sprintf("%s:%d-%d", res.URI, res.StartLine, res.EndLine),
 			Title:      res.Title,
+			Collection: res.Collection,
 			ModifiedAt: res.ModifiedAt,
 			Content:    content,
 			Truncated:  truncated,

--- a/internal/memory/shape.go
+++ b/internal/memory/shape.go
@@ -1,0 +1,79 @@
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// approxCharsPerToken is the rough characters-per-token ratio used to translate a
+// max_tokens budget into a character budget. mnemos runs no tokenizer at the
+// response boundary (that would pull a model dependency into the hot path), so a
+// token budget is honored approximately at ~4 chars/token — the common average
+// for English and code — and documented as approximate on the tool schema.
+const approxCharsPerToken = 4
+
+// charBudget resolves the effective character budget from a max_chars and a
+// max_tokens limit. A zero or negative value means "unbounded" for that axis;
+// when both are set the tighter one wins. It returns 0 when neither constrains.
+func charBudget(maxChars, maxTokens int) int {
+	budget := max(0, maxChars)
+	if maxTokens > 0 {
+		t := maxTokens * approxCharsPerToken
+		if budget == 0 || t < budget {
+			budget = t
+		}
+	}
+
+	return budget
+}
+
+// truncateContent cuts content to a character budget on a rune boundary and
+// appends an ellipsis marker, reporting whether it truncated. A zero budget, or
+// content already within budget, is returned unchanged with truncated=false so
+// the caller can decide whether to advertise a deeper read.
+func truncateContent(content string, budget int) (string, bool) {
+	if budget <= 0 || len(content) <= budget {
+		return content, false
+	}
+	// Step back to a rune start so a multi-byte rune is never split.
+	cut := budget
+	for cut > 0 && !utf8.RuneStart(content[cut]) {
+		cut--
+	}
+
+	return content[:cut] + " …", true
+}
+
+// lineRange is an inclusive 1-based [Start, End] source-line span parsed from a
+// "start-end" request string.
+type lineRange struct {
+	Start int
+	End   int
+}
+
+// parseLineRange parses a "start-end" span (both 1-based, inclusive) or a bare
+// "start" (a single line). It rejects malformed input and Start > End rather than
+// silently returning everything, so a typo does not read the whole document.
+func parseLineRange(s string) (lineRange, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return lineRange{}, errors.New("empty line range")
+	}
+	start, end, found := strings.Cut(s, "-")
+	lo, err := strconv.Atoi(strings.TrimSpace(start))
+	if err != nil || lo < 1 {
+		return lineRange{}, fmt.Errorf("invalid line range %q (want e.g. 10-42)", s)
+	}
+	if !found {
+		return lineRange{Start: lo, End: lo}, nil
+	}
+	hi, err := strconv.Atoi(strings.TrimSpace(end))
+	if err != nil || hi < lo {
+		return lineRange{}, fmt.Errorf("invalid line range %q (want e.g. 10-42)", s)
+	}
+
+	return lineRange{Start: lo, End: hi}, nil
+}

--- a/internal/memory/shape_internal_test.go
+++ b/internal/memory/shape_internal_test.go
@@ -1,0 +1,85 @@
+package memory
+
+import "testing"
+
+func TestCharBudget(t *testing.T) {
+	cases := []struct {
+		name             string
+		maxChars, maxTok int
+		want             int
+	}{
+		{"neither", 0, 0, 0},
+		{"chars only", 100, 0, 100},
+		{"tokens only", 0, 10, 40},
+		{"tokens tighter", 100, 10, 40},
+		{"chars tighter", 20, 10, 20},
+		{"negative ignored", -5, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := charBudget(tc.maxChars, tc.maxTok); got != tc.want {
+				t.Fatalf("charBudget(%d,%d) = %d, want %d", tc.maxChars, tc.maxTok, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTruncateContent(t *testing.T) {
+	s, trunc := truncateContent("hello world", 0)
+	if trunc || s != "hello world" {
+		t.Fatalf("zero budget must not truncate: %q trunc=%v", s, trunc)
+	}
+
+	s, trunc = truncateContent("hello world", 100)
+	if trunc || s != "hello world" {
+		t.Fatalf("within budget must not truncate: %q trunc=%v", s, trunc)
+	}
+
+	s, trunc = truncateContent("hello world", 5)
+	if !trunc {
+		t.Fatal("over budget must truncate")
+	}
+	if s != "hello …" {
+		t.Fatalf("truncated to %q, want %q", s, "hello …")
+	}
+}
+
+// TestTruncateContentRuneBoundary ensures a multi-byte rune is never split.
+func TestTruncateContentRuneBoundary(t *testing.T) {
+	// "héllo" — the é is two bytes (0xC3 0xA9) at bytes 1-2.
+	s, trunc := truncateContent("héllo", 2)
+	if !trunc {
+		t.Fatal("expected truncation")
+	}
+	// Budget 2 falls inside the é; it must step back to the rune start (byte 1).
+	if s != "h …" {
+		t.Fatalf("rune-split: got %q, want %q", s, "h …")
+	}
+}
+
+func TestParseLineRange(t *testing.T) {
+	ok := []struct {
+		in         string
+		start, end int
+	}{
+		{"10-42", 10, 42},
+		{"5", 5, 5},
+		{" 3 - 7 ", 3, 7},
+	}
+	for _, tc := range ok {
+		lr, err := parseLineRange(tc.in)
+		if err != nil {
+			t.Fatalf("parseLineRange(%q) errored: %v", tc.in, err)
+		}
+		if lr.Start != tc.start || lr.End != tc.end {
+			t.Fatalf("parseLineRange(%q) = %+v, want %d-%d", tc.in, lr, tc.start, tc.end)
+		}
+	}
+
+	bad := []string{"", "abc", "0-5", "10-3", "-4", "3-"}
+	for _, in := range bad {
+		if _, err := parseLineRange(in); err == nil {
+			t.Fatalf("parseLineRange(%q) should have errored", in)
+		}
+	}
+}

--- a/internal/memory/shape_service_test.go
+++ b/internal/memory/shape_service_test.go
@@ -1,0 +1,107 @@
+package memory_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/memory"
+	"github.com/arhuman/mnemos/internal/search"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+// seedTitled writes a markdown doc carrying a frontmatter title so tests can
+// assert the true documents.title is returned rather than a heading-derived one.
+const scimTitled = `---
+title: SCIM Provisioning Guide
+---
+
+# Provisioning
+
+SCIM provisioning syncs users automatically from the IdP.
+`
+
+func TestSearchReturnsTrueTitle(t *testing.T) {
+	f := newFixture(t, false, false)
+	f.seed(t, "docs/scim.md", scimTitled, "default")
+
+	results, err := f.svc.Search(context.Background(), f.retriever, search.Query{Text: "provisioning"})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	// The result carries the real documents.title, not a heading-derived label:
+	// it equals exactly what storage holds for the owning document.
+	doc, err := storage.GetDocumentByURI(context.Background(), f.db, results[0].URI)
+	require.NoError(t, err)
+	require.NotEmpty(t, doc.Title)
+	require.Equal(t, doc.Title, results[0].Title)
+}
+
+func TestReadDocumentSectionAndLinesScope(t *testing.T) {
+	f := newFixture(t, false, false)
+	uri := f.seed(t, "docs/scim.md", scimTitled, "default")
+	ctx := context.Background()
+
+	// A section that matches keeps the doc; one that matches nothing errors rather
+	// than returning an empty read.
+	got, err := f.svc.ReadDocumentOpts(ctx, uri, memory.ReadOptions{Section: "provisioning"})
+	require.NoError(t, err)
+	require.Contains(t, got.Content, "SCIM provisioning")
+
+	_, err = f.svc.ReadDocumentOpts(ctx, uri, memory.ReadOptions{Section: "no-such-heading"})
+	require.Error(t, err)
+
+	// A line span overlapping the body keeps it; one far past the doc errors.
+	// (Lines 1-3 are frontmatter; the body chunk starts at line 4.)
+	got, err = f.svc.ReadDocumentOpts(ctx, uri, memory.ReadOptions{Lines: "5-6"})
+	require.NoError(t, err)
+	require.NotEmpty(t, got.Content)
+
+	_, err = f.svc.ReadDocumentOpts(ctx, uri, memory.ReadOptions{Lines: "9000-9001"})
+	require.Error(t, err)
+
+	// A malformed range is a caller error, not a whole-document read.
+	_, err = f.svc.ReadDocumentOpts(ctx, uri, memory.ReadOptions{Lines: "bad"})
+	require.Error(t, err)
+}
+
+func TestReadBudgetTruncates(t *testing.T) {
+	f := newFixture(t, false, false)
+	uri := f.seed(t, "docs/scim.md", scimTitled, "default")
+	ctx := context.Background()
+
+	full, err := f.svc.ReadOne(ctx, uri, "")
+	require.NoError(t, err)
+	require.False(t, full.Truncated)
+
+	clipped, err := f.svc.ReadOneOpts(ctx, uri, "", memory.ReadOptions{MaxChars: 10})
+	require.NoError(t, err)
+	require.True(t, clipped.Truncated)
+	require.Less(t, len(clipped.Content), len(full.Content))
+}
+
+func TestContextGroupingAndBudget(t *testing.T) {
+	f := newFixture(t, false, false)
+	f.seed(t, "docs/a.md", "# Alpha\n\nprovisioning alpha content here.\n", "default")
+	f.seed(t, "docs/b.md", "# Beta\n\nprovisioning beta content here.\n", "default")
+	ctx := context.Background()
+	q := search.Query{Text: "provisioning", Limit: 10}
+
+	grouped, err := f.svc.ContextWithOptions(ctx, f.retriever, q, memory.ContextOptions{GroupByDocument: true})
+	require.NoError(t, err)
+	require.NotEmpty(t, grouped)
+	seen := make(map[string]bool)
+	for _, b := range grouped {
+		uri, _, ok := strings.Cut(b.Source, ":")
+		require.True(t, ok)
+		require.False(t, seen[uri], "document %q grouped more than once", uri)
+		seen[uri] = true
+	}
+
+	// A tight char budget clips block content and flags it.
+	budgeted, err := f.svc.ContextWithOptions(ctx, f.retriever, q, memory.ContextOptions{MaxChars: 5})
+	require.NoError(t, err)
+	require.NotEmpty(t, budgeted)
+	require.True(t, budgeted[0].Truncated)
+}

--- a/internal/memory/visibility_test.go
+++ b/internal/memory/visibility_test.go
@@ -1,0 +1,99 @@
+package memory_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/browse"
+	"github.com/arhuman/mnemos/internal/config"
+	"github.com/arhuman/mnemos/internal/ingest"
+	"github.com/arhuman/mnemos/internal/memory"
+	"github.com/arhuman/mnemos/internal/search"
+	"github.com/arhuman/mnemos/internal/testutil"
+)
+
+// newVisibilityFixture builds a read-only service whose config hides the given
+// collections, seeded with one "provisioning" doc per collection so a query
+// matches across all of them.
+func newVisibilityFixture(t *testing.T, deny []string, collections ...string) (*memory.Service, search.Retriever) {
+	t.Helper()
+
+	cfg, err := config.Load("", func(string) bool { return false })
+	require.NoError(t, err)
+	cfg.Security.Visibility.Deny = deny
+
+	db := testutil.NewDB(t)
+	logger := testutil.DiscardLogger()
+	treeRoot := t.TempDir()
+	testutil.Chdir(t, treeRoot)
+
+	for _, c := range collections {
+		rel := c + "/doc.md"
+		abs := testutil.WriteFile(t, treeRoot, rel, "# Provisioning\n\nSCIM provisioning notes for "+c+".\n")
+		_, _, err := ingest.File(context.Background(), db, logger, abs, filepath.ToSlash(rel), c, testChunking)
+		require.NoError(t, err)
+	}
+
+	return memory.New(db, cfg, treeRoot, nil, logger), search.NewEngine(db, logger)
+}
+
+func TestSearchHidesDeniedCollection(t *testing.T) {
+	svc, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+	ctx := context.Background()
+
+	results, err := svc.Search(ctx, ret, search.Query{Text: "provisioning"})
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	for _, r := range results {
+		require.NotEqual(t, "perso", r.Collection, "denied collection must never surface in search")
+	}
+	// The visible collection is still returned, with its provenance.
+	require.Equal(t, "mnemos", results[0].Collection)
+}
+
+// TestSearchDenyIgnoresCallerCollection proves the boundary is server-side: even
+// if the caller explicitly asks for the hidden collection, it stays hidden.
+func TestSearchDenyIgnoresCallerCollection(t *testing.T) {
+	svc, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+
+	results, err := svc.Search(context.Background(), ret, search.Query{Text: "provisioning", Collection: "perso"})
+	require.NoError(t, err)
+	require.Empty(t, results, "a hidden collection cannot be reached even when named explicitly")
+}
+
+func TestContextHidesDeniedCollection(t *testing.T) {
+	svc, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+
+	blocks, err := svc.ContextWithOptions(context.Background(), ret, search.Query{Text: "provisioning"}, memory.ContextOptions{GroupByDocument: true})
+	require.NoError(t, err)
+	require.NotEmpty(t, blocks)
+	for _, b := range blocks {
+		require.NotEqual(t, "perso", b.Collection, "denied collection must never surface in context")
+	}
+}
+
+func TestListHidesDeniedCollection(t *testing.T) {
+	svc, _ := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+
+	entries, err := svc.List(context.Background(), browse.Options{})
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	for _, e := range entries {
+		require.NotEqual(t, "perso", e.Collection, "denied collection must never surface in list")
+	}
+}
+
+func TestEmptyDenyShowsEverything(t *testing.T) {
+	svc, ret := newVisibilityFixture(t, nil, "mnemos", "perso")
+
+	results, err := svc.Search(context.Background(), ret, search.Query{Text: "provisioning", Limit: 20})
+	require.NoError(t, err)
+	got := make(map[string]bool)
+	for _, r := range results {
+		got[r.Collection] = true
+	}
+	require.True(t, got["mnemos"] && got["perso"], "empty deny list hides nothing")
+}

--- a/internal/memory/visibility_test.go
+++ b/internal/memory/visibility_test.go
@@ -2,6 +2,8 @@ package memory_test
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -12,13 +14,15 @@ import (
 	"github.com/arhuman/mnemos/internal/ingest"
 	"github.com/arhuman/mnemos/internal/memory"
 	"github.com/arhuman/mnemos/internal/search"
+	"github.com/arhuman/mnemos/internal/storage"
 	"github.com/arhuman/mnemos/internal/testutil"
 )
 
 // newVisibilityFixture builds a read-only service whose config hides the given
 // collections, seeded with one "provisioning" doc per collection so a query
-// matches across all of them.
-func newVisibilityFixture(t *testing.T, deny []string, collections ...string) (*memory.Service, search.Retriever) {
+// matches across all of them. The returned db lets read-path tests fetch a hidden
+// document's chunk id directly (search never reveals it).
+func newVisibilityFixture(t *testing.T, deny []string, collections ...string) (*memory.Service, *sql.DB, search.Retriever) {
 	t.Helper()
 
 	cfg, err := config.Load("", func(string) bool { return false })
@@ -37,11 +41,11 @@ func newVisibilityFixture(t *testing.T, deny []string, collections ...string) (*
 		require.NoError(t, err)
 	}
 
-	return memory.New(db, cfg, treeRoot, nil, logger), search.NewEngine(db, logger)
+	return memory.New(db, cfg, treeRoot, nil, logger), db, search.NewEngine(db, logger)
 }
 
 func TestSearchHidesDeniedCollection(t *testing.T) {
-	svc, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+	svc, _, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
 	ctx := context.Background()
 
 	results, err := svc.Search(ctx, ret, search.Query{Text: "provisioning"})
@@ -57,7 +61,7 @@ func TestSearchHidesDeniedCollection(t *testing.T) {
 // TestSearchDenyIgnoresCallerCollection proves the boundary is server-side: even
 // if the caller explicitly asks for the hidden collection, it stays hidden.
 func TestSearchDenyIgnoresCallerCollection(t *testing.T) {
-	svc, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+	svc, _, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
 
 	results, err := svc.Search(context.Background(), ret, search.Query{Text: "provisioning", Collection: "perso"})
 	require.NoError(t, err)
@@ -65,7 +69,7 @@ func TestSearchDenyIgnoresCallerCollection(t *testing.T) {
 }
 
 func TestContextHidesDeniedCollection(t *testing.T) {
-	svc, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+	svc, _, ret := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
 
 	blocks, err := svc.ContextWithOptions(context.Background(), ret, search.Query{Text: "provisioning"}, memory.ContextOptions{GroupByDocument: true})
 	require.NoError(t, err)
@@ -76,7 +80,7 @@ func TestContextHidesDeniedCollection(t *testing.T) {
 }
 
 func TestListHidesDeniedCollection(t *testing.T) {
-	svc, _ := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+	svc, _, _ := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
 
 	entries, err := svc.List(context.Background(), browse.Options{})
 	require.NoError(t, err)
@@ -87,7 +91,7 @@ func TestListHidesDeniedCollection(t *testing.T) {
 }
 
 func TestEmptyDenyShowsEverything(t *testing.T) {
-	svc, ret := newVisibilityFixture(t, nil, "mnemos", "perso")
+	svc, _, ret := newVisibilityFixture(t, nil, "mnemos", "perso")
 
 	results, err := svc.Search(context.Background(), ret, search.Query{Text: "provisioning", Limit: 20})
 	require.NoError(t, err)
@@ -96,4 +100,58 @@ func TestEmptyDenyShowsEverything(t *testing.T) {
 		got[r.Collection] = true
 	}
 	require.True(t, got["mnemos"] && got["perso"], "empty deny list hides nothing")
+}
+
+// TestReadHidesDeniedCollectionByURI proves mnemos.read cannot reach a hidden
+// collection by naming its document uri, and that the refusal is indistinguishable
+// from a genuinely absent uri (no existence oracle). The visible collection still
+// reads.
+func TestReadHidesDeniedCollectionByURI(t *testing.T) {
+	svc, _, _ := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+	ctx := context.Background()
+
+	// The hidden uri must return the exact "unknown uri" form the not-found
+	// branch produces for that same identifier — an absent "perso/absent.md"
+	// yields the identical shape, so read cannot be used as an existence oracle.
+	_, absentErr := svc.ReadDocument(ctx, "perso/absent.md")
+	require.EqualError(t, absentErr, `unknown uri "perso/absent.md"`)
+	_, hiddenErr := svc.ReadDocument(ctx, "perso/doc.md")
+	require.EqualError(t, hiddenErr, `unknown uri "perso/doc.md"`,
+		"a hidden collection must be unreadable by uri and shaped exactly like an absent one")
+
+	// A scoped read of the hidden uri must also report unknown-uri, not a
+	// section/line scope-mismatch (which would leak that the document exists).
+	_, scopedErr := svc.ReadDocumentOpts(ctx, "perso/doc.md", memory.ReadOptions{Section: "provisioning"})
+	require.EqualError(t, scopedErr, `unknown uri "perso/doc.md"`,
+		"a matching section on a hidden uri must not distinguish it from an absent one")
+
+	got, err := svc.ReadDocument(ctx, "mnemos/doc.md")
+	require.NoError(t, err, "a visible collection must remain readable")
+	require.Equal(t, "mnemos", got.Collection)
+}
+
+// TestReadHidesDeniedCollectionByChunkID proves the chunk read path enforces the
+// same boundary: a chunk in a hidden collection returns the same not-found as an
+// unknown chunk_id, while a visible chunk still reads.
+func TestReadHidesDeniedCollectionByChunkID(t *testing.T) {
+	svc, db, _ := newVisibilityFixture(t, []string{"perso"}, "mnemos", "perso")
+	ctx := context.Background()
+
+	hiddenChunks, err := storage.GetChunksByDocURI(ctx, db, "perso/doc.md")
+	require.NoError(t, err)
+	require.NotEmpty(t, hiddenChunks)
+
+	// A real chunk_id in a hidden collection must yield the same "unknown
+	// chunk_id" form the not-found branch produces for that id, not a distinct
+	// error that would confirm the chunk exists.
+	_, hiddenErr := svc.ReadChunk(ctx, hiddenChunks[0].ID)
+	require.EqualError(t, hiddenErr, fmt.Sprintf("unknown chunk_id %q", hiddenChunks[0].ID),
+		"a chunk in a hidden collection must be indistinguishable from an unknown chunk_id")
+
+	visibleChunks, err := storage.GetChunksByDocURI(ctx, db, "mnemos/doc.md")
+	require.NoError(t, err)
+	require.NotEmpty(t, visibleChunks)
+	got, err := svc.ReadChunk(ctx, visibleChunks[0].ID)
+	require.NoError(t, err, "a chunk in a visible collection must remain readable")
+	require.Equal(t, "mnemos", got.Collection)
 }

--- a/internal/memory/write.go
+++ b/internal/memory/write.go
@@ -96,13 +96,18 @@ func (s *Service) Remember(ctx context.Context, in RememberInput) (RememberResul
 		collection = "default"
 	}
 
-	filename, content := ingest.RenderOKF(ingest.CaptureInput{
+	// PrepareOKF preserves an authored document verbatim when the caller targets a
+	// path and the body already carries frontmatter (read-modify-write of a task
+	// state file, status.md, or a decision); otherwise it wraps the body in a
+	// generated frontmatter block. This stops a second block from shadowing the
+	// author's status/priority/title fields.
+	filename, content := ingest.PrepareOKF(ingest.CaptureInput{
 		Type:       noteType,
 		Body:       in.Text,
 		Tags:       in.Tags,
 		Collection: collection,
 		Timestamp:  time.Now(),
-	})
+	}, strings.TrimSpace(in.Path) != "")
 
 	// outExisted tells the log whether this write created or updated a concept.
 	absPath, uri, outExisted, err := s.writeNoteFile(in, filename, content)
@@ -112,9 +117,10 @@ func (s *Service) Remember(ctx context.Context, in RememberInput) (RememberResul
 
 	// Record the change in the note's directory log.md. The concept is already
 	// written, so a log-append failure is surfaced (wrapped) without losing it;
-	// reserved files never get their own log entry. The capture path always
-	// stamps the frontmatter timestamp to now (RenderOKF above), so timestamp
-	// reliably means "last modified" for both create and update.
+	// reserved files never get their own log entry. log.md is stamped with
+	// time.Now() below, so it records "last modified" for both create and update
+	// regardless of whether the frontmatter was generated (inbox capture) or
+	// authored (an explicit-path document preserved verbatim by PrepareOKF).
 	if base := filepath.Base(absPath); !okf.IsReservedOKFFile(base) {
 		kind := okf.LogCreation
 		if outExisted {

--- a/internal/memory/write_more_test.go
+++ b/internal/memory/write_more_test.go
@@ -2,7 +2,9 @@ package memory_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,6 +13,7 @@ import (
 	"github.com/arhuman/mnemos/internal/config"
 	"github.com/arhuman/mnemos/internal/memory"
 	"github.com/arhuman/mnemos/internal/search"
+	"github.com/arhuman/mnemos/internal/storage"
 	"github.com/arhuman/mnemos/internal/testutil"
 )
 
@@ -67,6 +70,41 @@ func TestRememberToPath(t *testing.T) {
 	// Traversal outside the tree is rejected by the confinement guard.
 	_, err = f.svc.Remember(ctx, memory.RememberInput{Type: "idea", Text: "x", Path: "../escape.md"})
 	require.ErrorContains(t, err, "remember path")
+}
+
+// TestRememberAuthoredTaskPreservesFrontmatter proves the frontmatter-merge fix
+// end to end: remembering a complete task document to an explicit path writes it
+// verbatim (a single frontmatter block, no generated one shadowing status/title)
+// and indexes it, so `mnemos task list` can group it by its own frontmatter.
+func TestRememberAuthoredTaskPreservesFrontmatter(t *testing.T) {
+	f := newFixture(t, true, false)
+	ctx := context.Background()
+
+	authored := "---\n" +
+		"type: task\n" +
+		"title: Ship the thing\n" +
+		"status: todo\n" +
+		"priority: high\n" +
+		"---\n\n## Goal\nship it\n"
+
+	res, err := f.svc.Remember(ctx, memory.RememberInput{
+		Type: "task", Text: authored, Path: "tasks/ship.md", Collection: "proj",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "tasks/ship.md", res.URI)
+	require.Positive(t, res.Chunks, "authored task parsed and indexed")
+
+	// Byte-for-byte on disk: no second frontmatter block was prepended.
+	onDisk, err := os.ReadFile(filepath.Join(f.treeRoot, "tasks", "ship.md"))
+	require.NoError(t, err)
+	require.Equal(t, authored, string(onDisk))
+	require.Equal(t, 2, strings.Count(string(onDisk), "---"), "exactly one frontmatter block")
+
+	// Indexed under its collection and reachable by uri.
+	doc, err := storage.GetDocumentByURI(ctx, f.db, "tasks/ship.md")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.Equal(t, "proj", doc.Collection)
 }
 
 // TestRememberDeferred covers the defer_to_watcher write-only branch: the file

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -120,14 +120,19 @@ type Link struct {
 }
 
 // Result is one ranked retrieval hit: the chunk that matched, its owning
-// document's uri/collection, the heading path and 1-based line range for
+// document's uri/collection/title, the heading path and 1-based line range for
 // citation, a highlighted snippet, and the final relevance score (higher is
 // better). It is the value a Retriever returns and the CLI/MCP layers render.
+// Title and ModifiedAt come from the owning documents row so callers need not
+// re-fetch the document to label or group a hit; both may be empty when the
+// document stored no title / no modified_at.
 type Result struct {
 	ID          string  `json:"id"`
 	DocumentID  string  `json:"document_id"`
 	URI         string  `json:"uri"`
 	Collection  string  `json:"collection"`
+	Title       string  `json:"title,omitempty"`
+	ModifiedAt  string  `json:"modified_at,omitempty"`
 	HeadingPath string  `json:"heading_path"`
 	StartLine   int     `json:"start_line"`
 	EndLine     int     `json:"end_line"`

--- a/internal/parse/frontmatter.go
+++ b/internal/parse/frontmatter.go
@@ -17,6 +17,7 @@ type frontmatterResult struct {
 	rawJSON    string
 	tags       []string
 	docType    string
+	title      string
 	modifiedAt string
 	// lineOffset is the number of source lines the frontmatter block consumed
 	// (including delimiters and the trailing blank line). Body line N maps to
@@ -38,9 +39,10 @@ func HasFrontmatter(content []byte) bool {
 
 // extractFrontmatter splits YAML frontmatter from content, returning the
 // remaining body when no frontmatter is present (body == content). Well-known
-// keys are mapped: `tags` (list), `type`→doc_type, `timestamp`→modified_at
-// fallback, `resource`→chunk metadata. The full matter is re-encoded as JSON
-// for documents.frontmatter_json.
+// keys are mapped: `tags` (list), `type`→doc_type, `title`→document title (takes
+// precedence over a heading-derived title), `timestamp`→modified_at fallback,
+// `resource`→chunk metadata. The full matter is re-encoded as JSON for
+// documents.frontmatter_json.
 func extractFrontmatter(content []byte) (frontmatterResult, error) {
 	var matter map[string]any
 	rest, err := frontmatter.Parse(bytes.NewReader(content), &matter)
@@ -58,6 +60,7 @@ func extractFrontmatter(content []byte) (frontmatterResult, error) {
 	}
 	res.tags = stringList(matter["tags"])
 	res.docType = asString(matter["type"])
+	res.title = strings.TrimSpace(asString(matter["title"]))
 	res.modifiedAt = asString(matter["timestamp"])
 	if r, ok := matter["resource"]; ok {
 		res.metadata = map[string]any{"resource": r}

--- a/internal/parse/markdown.go
+++ b/internal/parse/markdown.go
@@ -44,7 +44,7 @@ func (MarkdownParser) Parse(_ context.Context, src model.Source) (model.ParsedDo
 	// OKF index.md: structure only — a documents row, no chunks/links/FTS.
 	if strings.EqualFold(filepath.Base(src.URI), "index.md") {
 		doc.StructureOnly = true
-		doc.Title = titleFromBody(fm.body)
+		doc.Title = cmp.Or(fm.title, titleFromBody(fm.body))
 
 		return doc, nil
 	}
@@ -55,10 +55,10 @@ func (MarkdownParser) Parse(_ context.Context, src model.Source) (model.ParsedDo
 
 	doc.Sections = offsetSections(buildSections(root, body, idx), fm.lineOffset)
 	doc.Links = extractLinks(root, body, src.URI)
-	doc.Title = firstHeadingText(root, body)
-	if doc.Title == "" {
-		doc.Title = titleFromBody(body)
-	}
+	// An explicit frontmatter `title` wins; otherwise fall back to the first
+	// heading, then any non-empty body line. This keeps OKF documents (whose title
+	// lives in frontmatter) from being mislabelled by their first `##` heading.
+	doc.Title = cmp.Or(fm.title, firstHeadingText(root, body), titleFromBody(body))
 
 	return doc, nil
 }

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -30,6 +30,52 @@ func TestMarkdownFrontmatterMapping(t *testing.T) {
 	require.NotEmpty(t, doc.FrontmatterJSON)
 }
 
+func TestMarkdownTitlePrecedence(t *testing.T) {
+	cases := []struct {
+		name    string
+		uri     string
+		content string
+		want    string
+	}{
+		{
+			name:    "frontmatter title wins over heading",
+			uri:     "docs/x.md",
+			content: "---\ntitle: Real Title\n---\n\n## Goal\n\nbody\n",
+			want:    "Real Title",
+		},
+		{
+			name:    "heading used when no frontmatter title",
+			uri:     "docs/x.md",
+			content: "---\ntype: task\n---\n\n## Goal\n\nbody\n",
+			want:    "Goal",
+		},
+		{
+			name:    "body line used when neither title nor heading",
+			uri:     "docs/x.md",
+			content: "just a plain line\nmore\n",
+			want:    "just a plain line",
+		},
+		{
+			name:    "blank frontmatter title falls back to heading",
+			uri:     "docs/x.md",
+			content: "---\ntitle: \"   \"\n---\n\n## Goal\n\nbody\n",
+			want:    "Goal",
+		},
+		{
+			name:    "index.md honours frontmatter title",
+			uri:     "docs/index.md",
+			content: "---\ntitle: Bundle Title\n---\n\n# Heading\n",
+			want:    "Bundle Title",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := parseMarkdown(t, tc.uri, tc.content)
+			require.Equal(t, tc.want, doc.Title)
+		})
+	}
+}
+
 func TestMarkdownLineRangesAreFileAbsolute(t *testing.T) {
 	// 6 frontmatter lines + blank line 7; "# H" is file line 8.
 	content := "---\ntype: note\ntags: [a]\nresource: r\ntimestamp: t\n---\n\n# H\n\nbody\n"

--- a/internal/search/bm25.go
+++ b/internal/search/bm25.go
@@ -128,6 +128,7 @@ func filterClause(q Query) (conds []string, args []any) {
 func searchSQL(filterConds []string) string {
 	var b strings.Builder
 	_, _ = b.WriteString(`SELECT c.id, c.document_id, d.uri, d.collection, ` +
+		`COALESCE(d.title, ''), COALESCE(d.modified_at, ''), ` +
 		`COALESCE(c.heading_path, ''), c.start_line, c.end_line, ` +
 		`snippet(chunks_fts, 0, '[', ']', ' … ', 12) AS snip, ` +
 		`bm25(chunks_fts, `)

--- a/internal/search/bm25.go
+++ b/internal/search/bm25.go
@@ -115,8 +115,20 @@ func filterClause(q Query) (conds []string, args []any) {
 		conds = append(conds, "d.modified_at >= ?")
 		args = append(args, q.ModifiedSince)
 	}
+	if len(q.ExcludeCollections) > 0 {
+		conds = append(conds, "d.collection NOT IN ("+placeholders(len(q.ExcludeCollections))+")")
+		for _, c := range q.ExcludeCollections {
+			args = append(args, c)
+		}
+	}
 
 	return conds, args
+}
+
+// placeholders returns "?, ?, …" with n placeholders for an IN/NOT IN clause.
+// n is always >= 1 at the call site.
+func placeholders(n int) string {
+	return strings.TrimSuffix(strings.Repeat("?, ", n), ", ")
 }
 
 // searchSQL assembles the FTS5 retrieval statement. It joins the FTS virtual

--- a/internal/search/cliff.go
+++ b/internal/search/cliff.go
@@ -1,0 +1,41 @@
+package search
+
+import "github.com/arhuman/mnemos/internal/model"
+
+// cliffDropRatio and cliffFloorRatio tune RelevanceCliff. A hit scoring below
+// cliffDropRatio of its immediate predecessor is treated as falling off a cliff;
+// a hit below cliffFloorRatio of the top hit is treated as filler regardless of
+// the step from its predecessor. Both are relative so the heuristic is scale-free
+// across queries whose bm25 magnitudes differ by orders of magnitude. Kept
+// deliberately loose so only clear filler is trimmed, never a genuine long tail.
+const (
+	cliffDropRatio  = 0.4
+	cliffFloorRatio = 0.2
+)
+
+// RelevanceCliff trims a ranked result slice at the first steep score drop-off so
+// callers are not fed low-relevance filler just to reach the limit. results must
+// be sorted best-first. The top hit is always kept; the scan then cuts before the
+// first hit that is either far below the top score (the floor) or a steep
+// fraction of its predecessor (the cliff). It only trims — it never reorders or
+// grows the slice. When the top score is non-positive (e.g. a raw cosine ranking
+// where the ratios are not meaningful) the slice is returned unchanged rather
+// than guessing a cut.
+func RelevanceCliff(results []model.Result) []model.Result {
+	if len(results) <= 1 {
+		return results
+	}
+	top := results[0].Score
+	if top <= 0 {
+		return results
+	}
+	for i := 1; i < len(results); i++ {
+		prev := results[i-1].Score
+		cur := results[i].Score
+		if cur < cliffFloorRatio*top || (prev > 0 && cur < cliffDropRatio*prev) {
+			return results[:i]
+		}
+	}
+
+	return results
+}

--- a/internal/search/cliff_test.go
+++ b/internal/search/cliff_test.go
@@ -1,0 +1,56 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/arhuman/mnemos/internal/model"
+)
+
+// scores builds a ranked result slice from bare scores, best-first.
+func scores(vals ...float64) []model.Result {
+	out := make([]model.Result, len(vals))
+	for i, v := range vals {
+		out[i] = model.Result{Score: v}
+	}
+
+	return out
+}
+
+func TestRelevanceCliff(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []model.Result
+		want int // expected kept length
+	}{
+		{"empty", nil, 0},
+		{"single", scores(5), 1},
+		{"gentle slope keeps all", scores(10, 9, 8.5, 8), 4},
+		{"steep drop cuts at cliff", scores(10, 9, 2, 1.9), 2},
+		{"steep drop from top cuts immediately", scores(10, 3, 1.5), 1},
+		{"filler below floor cut", scores(10, 4.5, 1.9), 2},
+		{"top hit always kept even if next is zero", scores(10, 0), 1},
+		{"non-positive top left untouched", scores(-1, -2, -50), 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RelevanceCliff(tc.in)
+			if len(got) != tc.want {
+				t.Fatalf("kept %d results, want %d (scores %v)", len(got), tc.want, tc.in)
+			}
+		})
+	}
+}
+
+// TestRelevanceCliffNeverGrowsOrReorders guards the "only trims" contract.
+func TestRelevanceCliffNeverGrowsOrReorders(t *testing.T) {
+	in := scores(10, 9.5, 9, 1)
+	got := RelevanceCliff(in)
+	if len(got) > len(in) {
+		t.Fatalf("cliff grew the slice: %d > %d", len(got), len(in))
+	}
+	for i := range got {
+		if got[i].Score != in[i].Score {
+			t.Fatalf("cliff reordered at %d: got %v want %v", i, got[i].Score, in[i].Score)
+		}
+	}
+}

--- a/internal/search/engine.go
+++ b/internal/search/engine.go
@@ -78,10 +78,17 @@ func (e *Engine) Search(ctx context.Context, q Query) ([]model.Result, error) {
 		var r model.Result
 		var rank float64
 		if err := rows.Scan(
-			&r.ID, &r.DocumentID, &r.URI, &r.Collection,
+			&r.ID, &r.DocumentID, &r.URI, &r.Collection, &r.Title, &r.ModifiedAt,
 			&r.HeadingPath, &r.StartLine, &r.EndLine, &r.Snippet, &rank,
 		); err != nil {
 			return nil, fmt.Errorf("search: scan row: %w", err)
+		}
+		// snippet() covers column 0 (content) only, so a chunk that matched on its
+		// heading, tags, or doc_type — but whose content column is empty — yields an
+		// empty snippet. Fall back to the heading path so the hit still carries the
+		// signal that ranked it rather than a blank line.
+		if r.Snippet == "" {
+			r.Snippet = r.HeadingPath
 		}
 		// SQLite bm25() is negative with more-negative = better; flip it so the
 		// displayed score is positive and higher = better.

--- a/internal/search/graph.go
+++ b/internal/search/graph.go
@@ -1,0 +1,192 @@
+package search
+
+import (
+	"cmp"
+	"context"
+	"database/sql"
+	"log/slog"
+	"math"
+	"slices"
+
+	"github.com/arhuman/mnemos/internal/model"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+// defaultGraphSeedDepth and defaultGraphDecay are the fallbacks when the config
+// leaves the graph-expansion knobs unset.
+const (
+	defaultGraphSeedDepth = 3
+	defaultGraphDecay     = 0.5
+)
+
+// GraphRetriever wraps a base Retriever and, when the base under-fills the
+// requested limit, appends the 1-hop link neighbors of the top seed documents as
+// extra results. It is deliberately conservative: it never reorders or evicts a
+// base result, so ranking metrics (Hit@1, MRR) over base-covered queries cannot
+// regress; it only fills empty slots, so recall can rise when the answer document
+// is a link neighbor that shares no keywords with the query. Injected neighbors
+// carry a decayed seed score and the neighbor document's first chunk as citation.
+type GraphRetriever struct {
+	base      Retriever
+	db        *sql.DB
+	seedDepth int
+	decay     float64
+	logger    *slog.Logger
+}
+
+// NewGraphRetriever wraps base with link-neighbor expansion over db. seedDepth is
+// how many top hits are expanded (<= 0 uses the default); decay in (0,1] scales a
+// seed's score for its neighbors (<= 0 uses the default).
+func NewGraphRetriever(base Retriever, db *sql.DB, seedDepth int, decay float64, logger *slog.Logger) *GraphRetriever {
+	if seedDepth <= 0 {
+		seedDepth = defaultGraphSeedDepth
+	}
+	if decay <= 0 {
+		decay = defaultGraphDecay
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+
+	return &GraphRetriever{base: base, db: db, seedDepth: seedDepth, decay: decay, logger: logger}
+}
+
+// Search runs the base retriever, then fills any remaining slots up to the limit
+// with link neighbors of the top seed documents. Base results are returned
+// unchanged and in place; neighbors are only appended.
+func (g *GraphRetriever) Search(ctx context.Context, q Query) ([]model.Result, error) {
+	base, err := g.base.Search(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	limit := normalizeLimit(q.Limit)
+	room := limit - len(base)
+	if room <= 0 {
+		// Base already fills the limit: appending nothing keeps expansion strictly
+		// non-regressive at the requested depth.
+		return base, nil
+	}
+
+	seen := make(map[string]bool, len(base))
+	for _, r := range base {
+		seen[r.URI] = true
+	}
+	denied := make(map[string]bool, len(q.ExcludeCollections))
+	for _, c := range q.ExcludeCollections {
+		denied[c] = true
+	}
+
+	extra := make([]model.Result, 0, room)
+	for rank, seed := range distinctSeeds(base, g.seedDepth) {
+		weight := seed.score * math.Pow(g.decay, float64(rank+1))
+		for _, nuri := range g.resolvedNeighborURIs(ctx, seed.uri) {
+			if seen[nuri] {
+				continue
+			}
+			seen[nuri] = true
+			res, ok := g.neighborResult(ctx, nuri, weight, denied)
+			if ok {
+				extra = append(extra, res)
+			}
+		}
+	}
+
+	// Order neighbors by their decayed weight (higher first), stably, then take
+	// only enough to fill the empty slots.
+	slices.SortStableFunc(extra, func(a, b model.Result) int { return cmp.Compare(b.Score, a.Score) })
+	if len(extra) > room {
+		extra = extra[:room]
+	}
+
+	return append(base, extra...), nil
+}
+
+// seed is a base result reduced to what expansion needs: the document uri and its
+// score.
+type seed struct {
+	uri   string
+	score float64
+}
+
+// distinctSeeds returns the first n distinct-document base results (best-first),
+// preserving base order. Base results are already sorted best-first, so the first
+// occurrence of each uri is its best chunk.
+func distinctSeeds(base []model.Result, n int) []seed {
+	seen := make(map[string]bool, n)
+	out := make([]seed, 0, n)
+	for _, r := range base {
+		if seen[r.URI] {
+			continue
+		}
+		seen[r.URI] = true
+		out = append(out, seed{uri: r.URI, score: r.Score})
+		if len(out) >= n {
+			break
+		}
+	}
+
+	return out
+}
+
+// resolvedNeighborURIs returns the distinct uris of ingested (resolvable) 1-hop
+// neighbors of srcURI, both outbound and inbound. Dangling outbound targets are
+// dropped: they have no chunk to cite. Errors are logged and treated as "no
+// neighbors" so expansion never fails the base query.
+func (g *GraphRetriever) resolvedNeighborURIs(ctx context.Context, srcURI string) []string {
+	var uris []string
+	seen := make(map[string]bool)
+
+	add := func(ns []storage.Neighbor) {
+		for _, n := range ns {
+			if !n.Resolved || seen[n.URI] {
+				continue
+			}
+			seen[n.URI] = true
+			uris = append(uris, n.URI)
+		}
+	}
+
+	outbound, err := storage.OutboundNeighbors(ctx, g.db, srcURI)
+	if err != nil {
+		g.logger.Debug("graph expansion: outbound neighbors failed", "uri", srcURI, "err", err)
+	} else {
+		add(outbound)
+	}
+	inbound, err := storage.InboundNeighbors(ctx, g.db, srcURI)
+	if err != nil {
+		g.logger.Debug("graph expansion: inbound neighbors failed", "uri", srcURI, "err", err)
+	} else {
+		add(inbound)
+	}
+
+	return uris
+}
+
+// neighborResult builds a result for a neighbor document at uri with the given
+// score, or (zero, false) when the document is hidden, missing, or has no chunk
+// to cite. The citation is the document's first chunk, since the neighbor did not
+// match the query lexically and has no query-specific best chunk.
+func (g *GraphRetriever) neighborResult(ctx context.Context, uri string, score float64, denied map[string]bool) (model.Result, bool) {
+	doc, err := storage.GetDocumentByURI(ctx, g.db, uri)
+	if err != nil || doc == nil || denied[doc.Collection] {
+		return model.Result{}, false
+	}
+	chunk, err := storage.FirstChunkByDocURI(ctx, g.db, uri)
+	if err != nil || chunk == nil {
+		return model.Result{}, false
+	}
+
+	return model.Result{
+		ID:          chunk.ID,
+		DocumentID:  chunk.DocumentID,
+		URI:         doc.URI,
+		Collection:  doc.Collection,
+		Title:       doc.Title,
+		ModifiedAt:  doc.ModifiedAt,
+		HeadingPath: chunk.HeadingPath,
+		StartLine:   chunk.StartLine,
+		EndLine:     chunk.EndLine,
+		Snippet:     snippet(chunk.Content),
+		Score:       score,
+	}, true
+}

--- a/internal/search/graph_test.go
+++ b/internal/search/graph_test.go
@@ -1,0 +1,120 @@
+package search_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/model"
+	"github.com/arhuman/mnemos/internal/search"
+	"github.com/arhuman/mnemos/internal/storage"
+	"github.com/arhuman/mnemos/internal/testutil"
+)
+
+// putDoc inserts a document with a single searchable chunk.
+func putDoc(t *testing.T, db *sql.DB, id, uri, collection, content string) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.NoError(t, storage.UpsertDocument(ctx, tx, model.Document{
+		ID: id, URI: uri, Collection: collection, ContentHash: "h" + id, Title: id, IndexedAt: "t",
+	}))
+	require.NoError(t, storage.ReplaceChunks(ctx, tx, id, []model.Chunk{{
+		ID: id + "-c0", DocumentID: id, Ordinal: 0, Content: content, StartLine: 1, EndLine: 1,
+	}}))
+	require.NoError(t, tx.Commit())
+}
+
+func putLinks(t *testing.T, db *sql.DB, srcID string, dstURIs ...string) {
+	t.Helper()
+	links := make([]model.Link, 0, len(dstURIs))
+	for _, d := range dstURIs {
+		links = append(links, model.Link{SrcDoc: srcID, DstDoc: d})
+	}
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	require.NoError(t, storage.ReplaceLinks(context.Background(), tx, srcID, links))
+	require.NoError(t, tx.Commit())
+}
+
+func resultURIs(rs []model.Result) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.URI
+	}
+
+	return out
+}
+
+// TestGraphRetrieverInjectsNeighborWhenUnderfilled: a query hits only doc A, and
+// A links to B (which shares no keyword with the query). Expansion fills the empty
+// slots with B, so B is recovered without changing A's position.
+func TestGraphRetrieverInjectsNeighborWhenUnderfilled(t *testing.T) {
+	db := testutil.NewDB(t)
+	putDoc(t, db, "a", "a.md", "demo", "alpha unique-term-a")
+	putDoc(t, db, "b", "b.md", "demo", "beta unrelated-words")
+	putLinks(t, db, "a", "b.md") // a -> b
+
+	gr := search.NewGraphRetriever(search.NewEngine(db, nil), db, 3, 0.5, nil)
+	res, err := gr.Search(context.Background(), search.Query{Text: "alpha", Limit: 3})
+	require.NoError(t, err)
+
+	uris := resultURIs(res)
+	require.Equal(t, "a.md", uris[0], "base hit stays first")
+	require.Contains(t, uris, "b.md", "neighbor recovered into an empty slot")
+}
+
+// TestGraphRetrieverNeverEvictsBase: when the base already fills the limit,
+// expansion appends nothing, so the result is exactly the base list.
+func TestGraphRetrieverNeverEvictsBase(t *testing.T) {
+	db := testutil.NewDB(t)
+	putDoc(t, db, "a", "a.md", "demo", "alpha term")
+	putDoc(t, db, "b", "b.md", "demo", "beta term")
+	putLinks(t, db, "a", "b.md")
+
+	engine := search.NewEngine(db, nil)
+	gr := search.NewGraphRetriever(engine, db, 3, 0.5, nil)
+
+	// "term" matches both docs; limit 1 means the base already fills the limit.
+	base, err := engine.Search(context.Background(), search.Query{Text: "term", Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, base, 1)
+
+	got, err := gr.Search(context.Background(), search.Query{Text: "term", Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, resultURIs(base), resultURIs(got), "full base is returned unchanged")
+}
+
+// TestGraphRetrieverRespectsVisibilityDeny: a hidden-collection neighbor is not
+// injected even though the link exists.
+func TestGraphRetrieverRespectsVisibilityDeny(t *testing.T) {
+	db := testutil.NewDB(t)
+	putDoc(t, db, "a", "a.md", "demo", "alpha term-a")
+	putDoc(t, db, "b", "b.md", "secret", "beta term-b")
+	putLinks(t, db, "a", "b.md")
+
+	gr := search.NewGraphRetriever(search.NewEngine(db, nil), db, 3, 0.5, nil)
+	res, err := gr.Search(context.Background(), search.Query{
+		Text:               "alpha",
+		Limit:              3,
+		ExcludeCollections: []string{"secret"},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, resultURIs(res), "b.md", "hidden neighbor must not be injected")
+}
+
+// TestGraphRetrieverSkipsDanglingNeighbor: an outbound link to an un-ingested doc
+// has no chunk to cite, so it is never injected.
+func TestGraphRetrieverSkipsDanglingNeighbor(t *testing.T) {
+	db := testutil.NewDB(t)
+	putDoc(t, db, "a", "a.md", "demo", "alpha term-a")
+	putLinks(t, db, "a", "ghost.md") // dangling
+
+	gr := search.NewGraphRetriever(search.NewEngine(db, nil), db, 3, 0.5, nil)
+	res, err := gr.Search(context.Background(), search.Query{Text: "alpha", Limit: 3})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.md"}, resultURIs(res))
+}

--- a/internal/search/hybrid.go
+++ b/internal/search/hybrid.go
@@ -162,6 +162,7 @@ func (v *VectorRetriever) hydrate(ctx context.Context, scored []idScore) ([]mode
 	}
 
 	query := `SELECT c.id, c.document_id, d.uri, d.collection, ` +
+		`COALESCE(d.title, ''), COALESCE(d.modified_at, ''), ` +
 		`COALESCE(c.heading_path, ''), c.start_line, c.end_line, c.content ` +
 		`FROM chunks c JOIN documents d ON d.id = c.document_id ` +
 		`WHERE c.id IN (` + strings.Join(placeholders, ",") + `)`
@@ -177,13 +178,16 @@ func (v *VectorRetriever) hydrate(ctx context.Context, scored []idScore) ([]mode
 		var r model.Result
 		var content string
 		if err := rows.Scan(
-			&r.ID, &r.DocumentID, &r.URI, &r.Collection,
+			&r.ID, &r.DocumentID, &r.URI, &r.Collection, &r.Title, &r.ModifiedAt,
 			&r.HeadingPath, &r.StartLine, &r.EndLine, &content,
 		); err != nil {
 			return nil, fmt.Errorf("search: scan hydrated row: %w", err)
 		}
 		r.Score = scoreByID[r.ID]
 		r.Snippet = snippet(content)
+		if r.Snippet == "" {
+			r.Snippet = r.HeadingPath
+		}
 		out = append(out, r)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -23,6 +23,12 @@ type Query struct {
 	// ModifiedSince, when set, restricts results to documents.modified_at >= it.
 	// It is compared lexically, so an RFC3339 timestamp sorts correctly.
 	ModifiedSince string
+	// ExcludeCollections, when non-empty, drops every result whose
+	// documents.collection is in the list. It is the server-side visibility
+	// boundary ([security].visibility.deny): the memory service sets it from config
+	// on every query so a hidden collection can never surface, independent of the
+	// caller-supplied Collection filter.
+	ExcludeCollections []string
 	// Limit caps the result count. The caller supplies the configured default
 	// when it is not overridden on the command line.
 	Limit int

--- a/internal/storage/documents.go
+++ b/internal/storage/documents.go
@@ -165,7 +165,27 @@ type ListFilter struct {
 	// Status filters on the OKF status field in frontmatter (json_extract
 	// $.status), case-insensitive, with the same SQL/JSON semantics as DocType.
 	Status string
-	Limit  int
+	// ExcludeCollections drops rows whose collection is in the list — the
+	// server-side visibility boundary ([security].visibility.deny). Callers set it
+	// from config so a hidden collection never surfaces in list/task output.
+	ExcludeCollections []string
+	Limit              int
+}
+
+// whereExcludeCollections appends a `collection NOT IN (…)` condition and its
+// bound args when f hides any collections. Shared by the document list and digest
+// queries so both honor the visibility boundary identically.
+func whereExcludeCollections(where []string, args []any, f ListFilter) ([]string, []any) {
+	if len(f.ExcludeCollections) == 0 {
+		return where, args
+	}
+	ph := strings.TrimSuffix(strings.Repeat("?, ", len(f.ExcludeCollections)), ", ")
+	where = append(where, "collection NOT IN ("+ph+")")
+	for _, c := range f.ExcludeCollections {
+		args = append(args, c)
+	}
+
+	return where, args
 }
 
 // ListDocuments returns document metadata rows ordered by uri, narrowed by the
@@ -200,6 +220,7 @@ func ListDocuments(ctx context.Context, db *sql.DB, f ListFilter) ([]DocumentRow
 		where = append(where, "(CASE WHEN json_valid(frontmatter_json) THEN lower(json_extract(frontmatter_json, '$.status')) END) = lower(?)")
 		args = append(args, f.Status)
 	}
+	where, args = whereExcludeCollections(where, args, f)
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}
@@ -282,6 +303,7 @@ func ListDocumentDigests(ctx context.Context, db *sql.DB, f ListFilter) ([]Docum
 		where = append(where, "(CASE WHEN json_valid(frontmatter_json) THEN lower(json_extract(frontmatter_json, '$.status')) END) = lower(?)")
 		args = append(args, f.Status)
 	}
+	where, args = whereExcludeCollections(where, args, f)
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}

--- a/internal/storage/documents.go
+++ b/internal/storage/documents.go
@@ -157,7 +157,15 @@ type ListFilter struct {
 	Collection string // exact collection match
 	PathPrefix string // documents.uri starts with this slash-relative prefix
 	FileType   string // file extension without the dot (e.g. "md")
-	Limit      int
+	// DocType filters on the OKF document type in frontmatter (json_extract
+	// $.type), case-insensitive. Applied in SQL so callers do not scan every row
+	// and JSON-decode it in Go. Documents with absent or malformed frontmatter
+	// never match.
+	DocType string
+	// Status filters on the OKF status field in frontmatter (json_extract
+	// $.status), case-insensitive, with the same SQL/JSON semantics as DocType.
+	Status string
+	Limit  int
 }
 
 // ListDocuments returns document metadata rows ordered by uri, narrowed by the
@@ -180,6 +188,17 @@ func ListDocuments(ctx context.Context, db *sql.DB, f ListFilter) ([]DocumentRow
 	if f.FileType != "" {
 		where = append(where, "uri LIKE ? ESCAPE '\\'")
 		args = append(args, "%."+EscapeLike(f.FileType))
+	}
+	// The CASE guards json_extract against rows whose frontmatter_json is empty or
+	// malformed (json_extract on invalid JSON raises an error): it yields NULL for
+	// those, and NULL never equals the bound value, so they are excluded.
+	if f.DocType != "" {
+		where = append(where, "(CASE WHEN json_valid(frontmatter_json) THEN lower(json_extract(frontmatter_json, '$.type')) END) = lower(?)")
+		args = append(args, f.DocType)
+	}
+	if f.Status != "" {
+		where = append(where, "(CASE WHEN json_valid(frontmatter_json) THEN lower(json_extract(frontmatter_json, '$.status')) END) = lower(?)")
+		args = append(args, f.Status)
 	}
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
@@ -251,6 +270,17 @@ func ListDocumentDigests(ctx context.Context, db *sql.DB, f ListFilter) ([]Docum
 	if f.FileType != "" {
 		where = append(where, "uri LIKE ? ESCAPE '\\'")
 		args = append(args, "%."+EscapeLike(f.FileType))
+	}
+	// The CASE guards json_extract against rows whose frontmatter_json is empty or
+	// malformed (json_extract on invalid JSON raises an error): it yields NULL for
+	// those, and NULL never equals the bound value, so they are excluded.
+	if f.DocType != "" {
+		where = append(where, "(CASE WHEN json_valid(frontmatter_json) THEN lower(json_extract(frontmatter_json, '$.type')) END) = lower(?)")
+		args = append(args, f.DocType)
+	}
+	if f.Status != "" {
+		where = append(where, "(CASE WHEN json_valid(frontmatter_json) THEN lower(json_extract(frontmatter_json, '$.status')) END) = lower(?)")
+		args = append(args, f.Status)
 	}
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")

--- a/internal/storage/links.go
+++ b/internal/storage/links.go
@@ -34,3 +34,100 @@ func ReplaceLinks(ctx context.Context, tx *sql.Tx, srcDoc string, links []model.
 
 	return nil
 }
+
+// Neighbor is one 1-hop link-graph neighbor of a document: the connected
+// document plus the edge direction that reached it. For an outbound edge
+// Resolved is false when the target uri has no ingested document (a dangling
+// link), in which case Title and Collection are empty. Inbound neighbors are
+// always resolved, because the source of a link is a stored document.
+type Neighbor struct {
+	URI        string
+	Title      string
+	Collection string
+	Direction  string
+	Resolved   bool
+}
+
+// Direction values for a Neighbor.
+const (
+	DirOutbound = "outbound"
+	DirInbound  = "inbound"
+)
+
+// OutboundNeighbors returns the documents srcURI links to (its outbound edges),
+// left-joined to documents so a dangling target still surfaces with Resolved
+// false and empty title/collection. Ordered by target uri for stable output. An
+// unknown srcURI simply has no outbound edges and yields an empty slice.
+func OutboundNeighbors(ctx context.Context, db *sql.DB, srcURI string) ([]Neighbor, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT l.dst_doc, dst.title, dst.collection
+		FROM links l
+		JOIN documents src ON l.src_doc = src.id
+		LEFT JOIN documents dst ON dst.uri = l.dst_doc
+		WHERE src.uri = ?
+		ORDER BY l.dst_doc`, srcURI)
+	if err != nil {
+		return nil, fmt.Errorf("storage: outbound neighbors for %q: %w", srcURI, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Neighbor
+	for rows.Next() {
+		var (
+			n                 Neighbor
+			title, collection sql.NullString
+		)
+		if err := rows.Scan(&n.URI, &title, &collection); err != nil {
+			return nil, fmt.Errorf("storage: scan outbound neighbor: %w", err)
+		}
+		// documents.collection is NOT NULL, so a NULL here means the LEFT JOIN
+		// missed: the target uri is not an ingested document (dangling link).
+		n.Direction = DirOutbound
+		n.Resolved = collection.Valid
+		n.Title = title.String
+		n.Collection = collection.String
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: iterate outbound neighbors: %w", err)
+	}
+
+	return out, nil
+}
+
+// InboundNeighbors returns the documents that link to dstURI (its backlinks),
+// joined to their source document for title/collection. Always Resolved (a link
+// source is a stored document). Ordered by source uri. Relies on
+// idx_links_dst_doc (migration 0004) to avoid a full links scan.
+func InboundNeighbors(ctx context.Context, db *sql.DB, dstURI string) ([]Neighbor, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT src.uri, src.title, src.collection
+		FROM links l
+		JOIN documents src ON l.src_doc = src.id
+		WHERE l.dst_doc = ?
+		ORDER BY src.uri`, dstURI)
+	if err != nil {
+		return nil, fmt.Errorf("storage: inbound neighbors for %q: %w", dstURI, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Neighbor
+	for rows.Next() {
+		var (
+			n     Neighbor
+			title sql.NullString
+		)
+		if err := rows.Scan(&n.URI, &title, &n.Collection); err != nil {
+			return nil, fmt.Errorf("storage: scan inbound neighbor: %w", err)
+		}
+		n.Direction = DirInbound
+		n.Resolved = true
+		n.Title = title.String
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: iterate inbound neighbors: %w", err)
+	}
+
+	return out, nil
+}

--- a/internal/storage/list_test.go
+++ b/internal/storage/list_test.go
@@ -44,6 +44,15 @@ func TestListDocuments(t *testing.T) {
 		require.Equal(t, "notes/idea.txt", rows[0].URI)
 	})
 
+	t.Run("exclude collections", func(t *testing.T) {
+		rows, err := storage.ListDocuments(context.Background(), db, storage.ListFilter{ExcludeCollections: []string{"notes"}})
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		for _, r := range rows {
+			require.NotEqual(t, "notes", r.Collection, "hidden collection must not surface")
+		}
+	})
+
 	t.Run("by path prefix", func(t *testing.T) {
 		rows, err := storage.ListDocuments(context.Background(), db, storage.ListFilter{PathPrefix: "adr/"})
 		require.NoError(t, err)

--- a/internal/storage/migrations/0004_links_dst_index.sql
+++ b/internal/storage/migrations/0004_links_dst_index.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Index inbound link lookups (who links to X). Without it, backlink and
+-- neighbor-inbound queries scan the whole links table; links.dst_doc is a plain
+-- uri string, so the index is on the raw value joined to documents.uri.
+CREATE INDEX idx_links_dst_doc ON links(dst_doc);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_links_dst_doc;
+-- +goose StatementEnd

--- a/internal/storage/neighbors_bench_test.go
+++ b/internal/storage/neighbors_bench_test.go
@@ -1,0 +1,85 @@
+package storage_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/model"
+	"github.com/arhuman/mnemos/internal/storage"
+)
+
+// benchNeighborsDB builds a corpus of `docs` documents plus one "hub" document
+// with `fan` outbound links and `fan` inbound links, so the neighbor queries run
+// against a realistic mix rather than an empty table. The result is the marginal
+// cost read/context neighborhood injection would add per call. Returns the db and
+// the hub uri.
+func benchNeighborsDB(b *testing.B, docs, fan int) (*sql.DB, string) {
+	b.Helper()
+	db, err := storage.Open(context.Background(), filepath.Join(b.TempDir(), "bench.db"))
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = db.Close() })
+	require.NoError(b, storage.Migrate(db))
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(b, err)
+
+	require.NoError(b, storage.UpsertDocument(ctx, tx, doc("hub", "hub.md", "Hub")))
+	for i := range docs {
+		require.NoError(b, storage.UpsertDocument(ctx, tx, doc(fmt.Sprintf("d%d", i), fmt.Sprintf("docs/d%d.md", i), fmt.Sprintf("Doc %d", i))))
+	}
+
+	// Hub links out to the first `fan` docs.
+	outs := make([]model.Link, 0, fan)
+	for i := range fan {
+		outs = append(outs, model.Link{SrcDoc: "hub", DstDoc: fmt.Sprintf("docs/d%d.md", i)})
+	}
+	require.NoError(b, storage.ReplaceLinks(ctx, tx, "hub", outs))
+
+	// The next `fan` docs each link back to the hub (inbound edges).
+	for i := fan; i < 2*fan && i < docs; i++ {
+		id := fmt.Sprintf("d%d", i)
+		require.NoError(b, storage.ReplaceLinks(ctx, tx, id, []model.Link{{SrcDoc: id, DstDoc: "hub.md"}}))
+	}
+	require.NoError(b, tx.Commit())
+
+	return db, "hub.md"
+}
+
+func doc(id, uri, title string) model.Document {
+	return model.Document{
+		ID:          id,
+		URI:         uri,
+		Collection:  "demo",
+		ContentHash: "hash-" + id,
+		Title:       title,
+		IndexedAt:   "2026-01-01T00:00:00Z",
+	}
+}
+
+func BenchmarkOutboundNeighbors(b *testing.B) {
+	db, uri := benchNeighborsDB(b, 500, 25)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := storage.OutboundNeighbors(ctx, db, uri); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkInboundNeighbors(b *testing.B) {
+	db, uri := benchNeighborsDB(b, 500, 25)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := storage.InboundNeighbors(ctx, db, uri); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/storage/neighbors_test.go
+++ b/internal/storage/neighbors_test.go
@@ -1,0 +1,92 @@
+package storage_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/arhuman/mnemos/internal/model"
+	"github.com/arhuman/mnemos/internal/storage"
+	"github.com/arhuman/mnemos/internal/testutil"
+)
+
+func insertDoc(t *testing.T, db *sql.DB, id, uri, collection, title string) {
+	t.Helper()
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	require.NoError(t, storage.UpsertDocument(context.Background(), tx, model.Document{
+		ID:          id,
+		URI:         uri,
+		Collection:  collection,
+		ContentHash: "hash-" + id,
+		Title:       title,
+		IndexedAt:   "2026-01-01T00:00:00Z",
+	}))
+	require.NoError(t, tx.Commit())
+}
+
+func insertLinks(t *testing.T, db *sql.DB, srcID string, dstURIs ...string) {
+	t.Helper()
+	links := make([]model.Link, 0, len(dstURIs))
+	for _, d := range dstURIs {
+		links = append(links, model.Link{SrcDoc: srcID, DstDoc: d})
+	}
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	require.NoError(t, storage.ReplaceLinks(context.Background(), tx, srcID, links))
+	require.NoError(t, tx.Commit())
+}
+
+func TestOutboundAndInboundNeighbors(t *testing.T) {
+	ctx := context.Background()
+	db := testutil.NewDB(t)
+
+	// A -> B (resolved), A -> ghost.md (dangling); B -> A (resolved backlink).
+	insertDoc(t, db, "id-a", "a.md", "default", "Doc A")
+	insertDoc(t, db, "id-b", "b.md", "default", "Doc B")
+	insertLinks(t, db, "id-a", "b.md", "ghost.md")
+	insertLinks(t, db, "id-b", "a.md")
+
+	t.Run("outbound resolves targets and flags dangling", func(t *testing.T) {
+		out, err := storage.OutboundNeighbors(ctx, db, "a.md")
+		require.NoError(t, err)
+		require.Len(t, out, 2)
+
+		// Ordered by dst_doc: "b.md" before "ghost.md".
+		require.Equal(t, "b.md", out[0].URI)
+		require.True(t, out[0].Resolved)
+		require.Equal(t, "Doc B", out[0].Title)
+		require.Equal(t, "default", out[0].Collection)
+		require.Equal(t, storage.DirOutbound, out[0].Direction)
+
+		require.Equal(t, "ghost.md", out[1].URI)
+		require.False(t, out[1].Resolved)
+		require.Empty(t, out[1].Title)
+		require.Empty(t, out[1].Collection)
+	})
+
+	t.Run("inbound returns backlinks, always resolved", func(t *testing.T) {
+		in, err := storage.InboundNeighbors(ctx, db, "a.md")
+		require.NoError(t, err)
+		require.Len(t, in, 1)
+		require.Equal(t, "b.md", in[0].URI)
+		require.True(t, in[0].Resolved)
+		require.Equal(t, "Doc B", in[0].Title)
+		require.Equal(t, storage.DirInbound, in[0].Direction)
+	})
+
+	t.Run("dangling target has no inbound resolution but is reachable inbound by uri", func(t *testing.T) {
+		in, err := storage.InboundNeighbors(ctx, db, "ghost.md")
+		require.NoError(t, err)
+		require.Len(t, in, 1)
+		require.Equal(t, "a.md", in[0].URI)
+	})
+
+	t.Run("unknown source has no outbound edges", func(t *testing.T) {
+		out, err := storage.OutboundNeighbors(ctx, db, "nope.md")
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+}

--- a/internal/storage/read.go
+++ b/internal/storage/read.go
@@ -148,6 +148,32 @@ func GetChunksByDocURI(ctx context.Context, db *sql.DB, uri string) ([]model.Chu
 	return chunks, nil
 }
 
+// FirstChunkByDocURI returns the lowest-ordinal chunk of the document at uri, or
+// (nil, nil) when the document has no chunks. It is the representative chunk that
+// graph expansion cites for a neighbor document which did not match the query
+// lexically, so the injected result still carries a real citation.
+func FirstChunkByDocURI(ctx context.Context, db *sql.DB, uri string) (*model.Chunk, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT c.id, c.document_id, c.ordinal, c.heading_path, c.content,
+		       c.tags, c.doc_type, c.token_count, c.start_line, c.end_line, c.metadata_json
+		FROM chunks c
+		JOIN documents d ON d.id = c.document_id
+		WHERE d.uri = ?
+		ORDER BY c.ordinal
+		LIMIT 1
+	`, uri)
+
+	c, err := scanChunk(row)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, nil //nolint:nilnil // documented not-found result: (nil, nil) means the document has no chunks
+	case err != nil:
+		return nil, fmt.Errorf("storage: first chunk for %q: %w", uri, err)
+	default:
+		return c, nil
+	}
+}
+
 // scanner abstracts *sql.Row and *sql.Rows so the scan helpers serve both the
 // single-row and multi-row accessors.
 type scanner interface {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -87,15 +87,28 @@ type Options struct {
 
 // Resolve determines the MNEMOS_DIR and its Layout by precedence:
 //
-//  1. --config <file>      → MnemosDir is the file's directory; Config is the file
-//  2. --mnemos-dir <dir>   → that directory
-//  3. $MNEMOS_DIR          → that directory
-//  4. project ./.mnemos    → nearest one walking up from cwd, bounded by the git
+//  1. --config <file>       → MnemosDir is the file's directory; Config is the file
+//  2. --mnemos-dir <dir>    → that directory
+//  3. $MNEMOS_DIR           → that directory
+//  4. $CLAUDE_PROJECT_DIR   → resolve within that project, FAIL CLOSED: if the
+//     project has no .mnemos, bind to its canonical (uninitialized) location so the
+//     absent database yields an actionable "run mnemos init" error, never a silent
+//     fall-through to the global default. Claude Code sets this variable in a
+//     spawned MCP server's environment, so an unpinned `serve` lands on the right
+//     project's workspace instead of leaking the global one.
+//  5. project ./.mnemos     → nearest one walking up from cwd, bounded by the git
 //     root (so an unrelated parent's .mnemos is never picked up)
-//  5. ~/.mnemos            → the global default
+//  6. ~/.mnemos             → the global default (reached only when no project
+//     context is signalled)
 //
 // The chosen directory need not exist; commands that read state fail with an
 // actionable error when the database is absent.
+//
+// MCP roots/list would be a more robust project signal than $CLAUDE_PROJECT_DIR,
+// but the client only answers it inside an initialized session — after serve has
+// already opened the store — so consuming it requires deferring workspace
+// resolution and DB binding until post-init. That lifecycle change is tracked
+// separately; $CLAUDE_PROJECT_DIR gives the same routing at process start.
 func Resolve(opts Options) (Layout, error) {
 	env := opts.Env
 	if env == nil {
@@ -132,6 +145,28 @@ func Resolve(opts Options) (Layout, error) {
 		}
 		l := New(abs)
 		l.Source = "$MNEMOS_DIR"
+
+		return l, nil
+	}
+
+	// A CLAUDE_PROJECT_DIR signals a project session (Claude Code sets it in the
+	// spawned server's environment). Resolve within that project and fail closed:
+	// if it has no .mnemos, bind to its canonical uninitialized location so an
+	// absent database surfaces "run mnemos init" rather than silently serving the
+	// global ~/.mnemos — the wrong-project leak this precedence exists to prevent.
+	if cpd := env("CLAUDE_PROJECT_DIR"); cpd != "" {
+		if proj := findProjectDir(cpd); proj != "" {
+			l := New(proj)
+			l.Source = "project $CLAUDE_PROJECT_DIR"
+
+			return l, nil
+		}
+		abs, err := filepath.Abs(cpd)
+		if err != nil {
+			return Layout{}, fmt.Errorf("workspace: resolve $CLAUDE_PROJECT_DIR %q: %w", cpd, err)
+		}
+		l := New(filepath.Join(abs, DirName))
+		l.Source = "project $CLAUDE_PROJECT_DIR (uninitialized)"
 
 		return l, nil
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -67,6 +67,72 @@ func TestResolveEnvBeatsProjectAndDefault(t *testing.T) {
 	require.Contains(t, l.Source, "MNEMOS_DIR")
 }
 
+func TestResolveClaudeProjectDirFound(t *testing.T) {
+	// $CLAUDE_PROJECT_DIR points at a project that has a .mnemos: use it.
+	proj := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(proj, ".mnemos"), 0o750))
+
+	l, err := workspace.Resolve(workspace.Options{
+		Env:  func(k string) string { return map[string]string{"CLAUDE_PROJECT_DIR": proj}[k] },
+		Home: "/home/u",
+		Cwd:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(proj, ".mnemos"), l.MnemosDir)
+	require.Contains(t, l.Source, "CLAUDE_PROJECT_DIR")
+}
+
+func TestResolveClaudeProjectDirFailsClosedNotGlobal(t *testing.T) {
+	// $CLAUDE_PROJECT_DIR is set but the project has no .mnemos: bind to its
+	// canonical (uninitialized) location, NEVER fall through to ~/.mnemos.
+	proj := t.TempDir()
+
+	l, err := workspace.Resolve(workspace.Options{
+		Env:  func(k string) string { return map[string]string{"CLAUDE_PROJECT_DIR": proj}[k] },
+		Home: "/home/u",
+		Cwd:  t.TempDir(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(proj, ".mnemos"), l.MnemosDir)
+	require.NotEqual(t, filepath.Join("/home/u", ".mnemos"), l.MnemosDir)
+	require.Contains(t, l.Source, "uninitialized")
+}
+
+func TestResolveClaudeProjectDirBeatsCwd(t *testing.T) {
+	// A project session ($CLAUDE_PROJECT_DIR, no .mnemos) must win over a cwd that
+	// happens to have a .mnemos: the session's project is authoritative, and it
+	// fails closed rather than picking up the cwd workspace.
+	proj := t.TempDir()
+	cwd := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(cwd, ".mnemos"), 0o750))
+
+	l, err := workspace.Resolve(workspace.Options{
+		Env:  func(k string) string { return map[string]string{"CLAUDE_PROJECT_DIR": proj}[k] },
+		Home: "/home/u",
+		Cwd:  cwd,
+	})
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(proj, ".mnemos"), l.MnemosDir)
+	require.NotEqual(t, filepath.Join(cwd, ".mnemos"), l.MnemosDir)
+}
+
+func TestResolveEnvDirBeatsClaudeProjectDir(t *testing.T) {
+	// $MNEMOS_DIR (precedence 3) still wins over $CLAUDE_PROJECT_DIR (precedence 4).
+	envDir := t.TempDir()
+	proj := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(proj, ".mnemos"), 0o750))
+
+	l, err := workspace.Resolve(workspace.Options{
+		Env: func(k string) string {
+			return map[string]string{"MNEMOS_DIR": envDir, "CLAUDE_PROJECT_DIR": proj}[k]
+		},
+		Home: "/home/u",
+	})
+	require.NoError(t, err)
+	require.Equal(t, envDir, l.MnemosDir)
+	require.Contains(t, l.Source, "MNEMOS_DIR")
+}
+
 func TestResolveProjectDirWalkingUp(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".mnemos"), 0o750))

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,22 @@
+commit-msg:
+  commands:
+    # Dependency-free Conventional Commits check matching release.sh regex.
+    # Validates commit message subject against: type(scope)?: description
+    conventional-commits:
+      glob: ""
+      run: |
+        msg=$(head -1 "{1}")
+        pattern='^[a-z]+(\([^)]*\))?!?:'
+        if ! echo "$msg" | grep -qE "$pattern"; then
+          echo "Commit message violates Conventional Commits format: '$msg'"
+          echo ""
+          echo "Expected format: type(scope)?: description"
+          echo "Valid types: feat, fix, docs, chore, test, refactor, build, perf, ci, style"
+          echo ""
+          echo "Examples:"
+          echo "  feat: add new feature"
+          echo "  feat(scope): add new feature with scope"
+          echo "  fix(cli): resolve issue"
+          echo "  docs: update README"
+          exit 1
+        fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# release.sh: cut a release with minimal ceremony. Language-agnostic; the only
+# project hook is the `make ci` gate, so it drops into any standard repo.
+#
+# Derives the next semantic version from the Conventional Commits made since the
+# last v* tag (feat -> minor, fix/other -> patch, ! or BREAKING CHANGE -> major,
+# capped to minor while still on 0.x), lets the caller confirm or override it,
+# runs the gate (make ci), stamps CHANGELOG.md, then commits, tags and pushes.
+# Pushing the tag is what triggers .github/workflows/release.yml -> goreleaser.
+#
+# Invoked by the Makefile `release` target: `make release`.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+changelog="CHANGELOG.md"
+
+die() { echo "release: $*" >&2; exit 1; }
+
+# --- preconditions -----------------------------------------------------------
+[ -z "$(git status --porcelain)" ] || die "working tree not clean; commit or stash first"
+branch=$(git rev-parse --abbrev-ref HEAD)
+[ "$branch" = main ] || [ "$branch" = master ] || die "not on main/master (on $branch)"
+[ -f "$changelog" ] || die "$changelog not found"
+
+# --- last tag + bump detection ----------------------------------------------
+last=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+if [ -z "$last" ]; then
+  last="v0.0.0"; range="HEAD"
+else
+  range="${last}..HEAD"
+fi
+IFS=. read -r major minor patch <<<"${last#v}"
+
+subjects=$(git log "$range" --no-merges --format='%s')
+[ -n "$subjects" ] || die "no commits since $last; nothing to release"
+bodies=$(git log "$range" --no-merges --format='%B')
+
+bump=patch
+if printf '%s\n' "$subjects" | grep -qE '^[a-z]+(\([^)]+\))?!:' \
+   || printf '%s\n' "$bodies" | grep -qE '^BREAKING CHANGE'; then
+  bump=major
+elif printf '%s\n' "$subjects" | grep -qE '^feat(\([^)]+\))?:'; then
+  bump=minor
+fi
+# SemVer 0.x: a breaking change bumps minor, not major, until the first 1.0.0.
+[ "$major" -eq 0 ] && [ "$bump" = major ] && bump=minor
+
+case "$bump" in
+  major) major=$((major + 1)); minor=0; patch=0 ;;
+  minor) minor=$((minor + 1)); patch=0 ;;
+  patch) patch=$((patch + 1)) ;;
+esac
+suggested="v${major}.${minor}.${patch}"
+
+# --- confirm / override ------------------------------------------------------
+n_all=$(git rev-list --count --no-merges "$range")
+n_feat=$(printf '%s\n' "$subjects" | grep -cE '^feat' || true)
+n_fix=$(printf '%s\n' "$subjects" | grep -cE '^fix' || true)
+echo "Last tag       : $last"
+echo "Commits since  : $n_all ($n_feat feat, $n_fix fix)  ->  bump = $bump"
+printf 'Version [%s]: ' "$suggested"
+read -r chosen </dev/tty || true
+version=${chosen:-$suggested}
+[[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "invalid version '$version' (want vMAJOR.MINOR.PATCH)"
+git rev-parse "$version" >/dev/null 2>&1 && die "tag $version already exists"
+
+# --- gate --------------------------------------------------------------------
+echo "Running make ci ..."
+make ci
+[ -z "$(git status --porcelain)" ] || die "make ci left changes (fmt/tidy?); commit them and re-run"
+
+# --- stamp CHANGELOG ---------------------------------------------------------
+# Promote the [Unreleased] section: keep an empty [Unreleased] on top and open
+# a new dated version heading beneath it, over the accumulated changes.
+today=$(date +%F)
+tmp=$(mktemp)
+awk -v ver="${version#v}" -v date="$today" '
+  !stamped && /^## \[Unreleased\]/ {
+    print "## [Unreleased]"; print "";
+    print "## [" ver "] - " date;
+    stamped = 1; next
+  }
+  { print }
+' "$changelog" > "$tmp" && mv "$tmp" "$changelog"
+grep -qF "## [${version#v}] - $today" "$changelog" || die "failed to stamp $changelog (no '## [Unreleased]' heading?)"
+
+# --- commit, tag, push -------------------------------------------------------
+git add "$changelog"
+git commit -m "chore(release): $version"
+git tag -a "$version" -m "$version"
+git push origin "$branch"
+git push origin "$version"
+
+echo "Pushed $version. release.yml -> goreleaser is now building."

--- a/skills/mnemos-okf/hooks/settings.example.json
+++ b/skills/mnemos-okf/hooks/settings.example.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v mnemos >/dev/null || exit 0; echo '## mnemos working set'; mnemos task list 2>/dev/null; echo; echo '### Recent decisions'; mnemos ls decisions --limit 5 2>/dev/null; exit 0"
+            "command": "command -v mnemos >/dev/null || exit 0; echo '## mnemos working set'; mnemos task list 2>/dev/null; echo; echo '### Recent decisions'; mnemos ls decisions --limit 5 2>/dev/null; exit 0 # mnemos-okf-hook"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v mnemos >/dev/null && command -v jq >/dev/null || exit 0; p=$(jq -r '.prompt // empty'); [ -n \"$p\" ] || exit 0; printf '%s' \"$p\" | grep -qiE 'as we decided|what was|remember when|why did we|the usual|comme on avait|c.etait quoi' || exit 0; echo '## mnemos recall (top 3, verify before use)'; mnemos search \"$p\" --limit 3 2>/dev/null; exit 0"
+            "command": "command -v mnemos >/dev/null && command -v jq >/dev/null || exit 0; p=$(jq -r '.prompt // empty'); [ -n \"$p\" ] || exit 0; printf '%s' \"$p\" | grep -qiE 'as we decided|what was|remember when|why did we|the usual|comme on avait|c.etait quoi' || exit 0; echo '## mnemos recall (top 3, verify before use)'; mnemos search \"$p\" --limit 3 2>/dev/null; exit 0 # mnemos-okf-hook"
           }
         ]
       }

--- a/skills/mnemos-okf/hooks/settings.example.json
+++ b/skills/mnemos-okf/hooks/settings.example.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v mnemos >/dev/null || exit 0; echo '## mnemos working set'; mnemos task list 2>/dev/null; echo; echo '### Recent decisions'; mnemos ls decisions --limit 5 2>/dev/null; exit 0 # mnemos-okf-hook"
+            "command": "command -v mnemos >/dev/null || exit 0; mnemos hook session-start 2>/dev/null; exit 0 # mnemos-okf-hook"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v mnemos >/dev/null && command -v jq >/dev/null || exit 0; p=$(jq -r '.prompt // empty'); [ -n \"$p\" ] || exit 0; printf '%s' \"$p\" | grep -qiE 'as we decided|what was|remember when|why did we|the usual|comme on avait|c.etait quoi' || exit 0; echo '## mnemos recall (top 3, verify before use)'; mnemos search \"$p\" --limit 3 2>/dev/null; exit 0 # mnemos-okf-hook"
+            "command": "command -v mnemos >/dev/null || exit 0; mnemos hook recall 2>/dev/null; exit 0 # mnemos-okf-hook"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Conformance audit against the 10x engineering standard v1.8 (`public` profile) found one confirmed P0 lead that turned out to be a false positive on manual review, and three confirmed real gaps, all fixed here:

- `release.script`: added `scripts/release.sh` (derives semver from Conventional Commits, gates on `make ci`, stamps CHANGELOG.md, tags and pushes) plus `make ci`/`make release` targets.
- `commit.ci_check`: Conventional Commits are now enforced in CI (dependency-free, pure shell, no new toolchain) and locally via a `lefthook` commit-msg hook (`make git-hooks`).
- `supply_chain.sign_sbom`: `goreleaser` now emits an SBOM (syft) and signs release artifacts (cosign, keyless OIDC); `release.yml` gained the matching installer steps and `id-token: write` permission.

`ci.audit`'s probe looks for a literal `make audit` call in CI and reports FAIL, but `.github/workflows/ci.yml` already runs the same checks (`go mod verify`, golangci-lint, govulncheck, `make cover`) as separate steps across two jobs, plus a 2-Go-version matrix, an embed-tag build, and a benchmark smoke test `make audit` alone doesn't cover. Confirmed as not a real gap; left unchanged.

Full audit trail: `.claude/doc/conformance-mnemos.md` (local-only, not part of this PR).

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `bash -n scripts/release.sh` syntax check
- [x] `make ci`/`make release`/`make git-hooks` parse and the new `ci` target's sub-steps run in order
- [x] Conventional Commits regex validated against 15 real historical commit subjects (all pass) and against known-bad shapes (rejected)
- [x] Re-ran the standard v1.8 conformance runner: all three confirmed gaps now PASS, no new regressions
- [ ] SBOM/signing cannot be verified without cutting a real tagged release; that step is out of scope for this PR